### PR TITLE
Separate --mirror argument from CPAN_MIRROR env var

### DIFF
--- a/5.16/s2i/bin/assemble
+++ b/5.16/s2i/bin/assemble
@@ -14,6 +14,12 @@ fi
 
 export CPAN_MIRROR=${CPAN_MIRROR:-""}
 
+MIRROR_ARGS=""
+
+if [ -n "$CPAN_MIRROR" ]; then
+  MIRROR_ARGS="--mirror $CPAN_MIRROR"
+fi
+
 # Don't test installed Perl modules by default
 if [ "${ENABLE_CPAN_TEST}" = true ]; then
   export ENABLE_CPAN_TEST=""
@@ -29,8 +35,8 @@ if [ -f "cpanfile" ]; then
     perl - App::cpanminus
   CPANM="./perl5/bin/cpanm"
   echo "---> Installing modules from cpanfile ..."
-  perl $CPANM $CPAN_MIRROR $ENABLE_CPAN_TEST -l extlib Module::CoreList
-  perl -Iextlib/lib/perl5 $CPANM $CPAN_MIRROR $ENABLE_CPAN_TEST -l extlib --installdeps .
+  perl $CPANM $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib Module::CoreList
+  perl -Iextlib/lib/perl5 $CPANM $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib --installdeps .
 else
   echo "---> No cpanfile found, nothing to install"
 fi

--- a/5.20/s2i/bin/assemble
+++ b/5.20/s2i/bin/assemble
@@ -14,6 +14,12 @@ fi
 
 export CPAN_MIRROR=${CPAN_MIRROR:-""}
 
+MIRROR_ARGS=""
+
+if [ -n "$CPAN_MIRROR" ]; then
+  MIRROR_ARGS="--mirror $CPAN_MIRROR"
+fi
+
 # Don't test installed Perl modules by default
 if [ "${ENABLE_CPAN_TEST}" = true ]; then
   export ENABLE_CPAN_TEST=""
@@ -59,8 +65,8 @@ if [ -f "cpanfile" ]; then
     perl - App::cpanminus
   CPANM="./perl5/bin/cpanm"
   echo "---> Installing modules from cpanfile ..."
-  perl $CPANM $CPAN_MIRROR $ENABLE_CPAN_TEST -l extlib Module::CoreList
-  perl -Iextlib/lib/perl5 $CPANM $CPAN_MIRROR $ENABLE_CPAN_TEST -l extlib --installdeps .
+  perl $CPANM $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib Module::CoreList
+  perl -Iextlib/lib/perl5 $CPANM $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib --installdeps .
 else
   echo "---> No cpanfile found, nothing to install"
 fi


### PR DESCRIPTION
Currently, users need to add '--mirror' option along with mirror URL
in CPAN_MIRROR env var in order to work correctly. However, that option
'--mirror' shouldn't be a part of CPAN_MIRROR as it's rather confusing
to add an option into an env var that is used for mirror URL only.

Signed-off-by: Vu Dinh <vdinh@redhat.com>