### PR TITLE
Handle uppercase HTTP_PROXY

### DIFF
--- a/5.16/s2i/bin/assemble
+++ b/5.16/s2i/bin/assemble
@@ -13,6 +13,10 @@ if [ -d ./cfg ]; then
   fi
 fi
 
+if [[ -n "${HTTP_PROXY:-}" && -z "${http_proxy:-}" ]]; then
+  export http_proxy=$HTTP_PROXY
+fi
+
 export CPAN_MIRROR=${CPAN_MIRROR:-""}
 
 MIRROR_ARGS=""
@@ -32,7 +36,7 @@ fi
 if [ -f "cpanfile" ]; then
   # Install cpanm
   echo "---> Installing cpanminus 1.7102 ..."
-  curl -skL https://raw.githubusercontent.com/miyagawa/cpanminus/1.7102/cpanm |\
+  curl -sSkL https://raw.githubusercontent.com/miyagawa/cpanminus/1.7102/cpanm |\
     perl - App::cpanminus
   CPANM="./perl5/bin/cpanm"
   echo "---> Installing modules from cpanfile ..."

--- a/5.20/s2i/bin/assemble
+++ b/5.20/s2i/bin/assemble
@@ -13,6 +13,10 @@ if [ -d ./cfg ]; then
   fi
 fi
 
+if [[ -n "${HTTP_PROXY:-}" && -z "${http_proxy:-}" ]]; then
+  export http_proxy=$HTTP_PROXY
+fi
+
 export CPAN_MIRROR=${CPAN_MIRROR:-""}
 
 MIRROR_ARGS=""
@@ -62,7 +66,7 @@ fi
 if [ -f "cpanfile" ]; then
   # Install cpanm
   echo "---> Installing cpanminus 1.7102 ..."
-  curl -skL https://raw.githubusercontent.com/miyagawa/cpanminus/1.7102/cpanm |\
+  curl -sSkL https://raw.githubusercontent.com/miyagawa/cpanminus/1.7102/cpanm |\
     perl - App::cpanminus
   CPANM="./perl5/bin/cpanm"
   echo "---> Installing modules from cpanfile ..."


### PR DESCRIPTION
Curl and cpanm ignore HTTP_PROXY and only use http_proxy. Set http_proxy
to HTTP_PROXY in case only the later is set.

Output error if curl fails.