### PR TITLE
Fix squashing in CentOS

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -48,7 +48,7 @@ function docker_build_with_version {
 function squash {
   # FIXME: We have to use the exact versions here to avoid Docker client
   #        compatibility issues
-  easy_install -q --user docker_py==1.6.0 docker-squash==1.0.0rc6
+  easy_install -q --user docker_py==1.7.2 docker-squash==1.0.1
   base=$(awk '/^FROM/{print $2}' $1)
   ${HOME}/.local/bin/docker-squash -f $base ${IMAGE_NAME}
 }


### PR DESCRIPTION
Docker-squash requires docker_py >= 1.7.2, so "easy_install -q --user docker_py==1.6.0 docker-squash==1.0.0rc6" resolves to install latest docker_py version which requires new setuptools with environment markers support. So this command success in CentOS only with latest rh-python35.

Also updated to use latest docker-squash.

@hhorak @bparees Please test. This PR is same as sclorg/mariadb-container#9