### PR TITLE
rh-perl524 support

### DIFF
--- a/5.20/test/run
+++ b/5.20/test/run
@@ -204,13 +204,32 @@ test_application() {
 # Second argument is function that expects running application. The function
 # must return (or terminate with) non-zero value to report an failure,
 # 0 otherwise.
-# Third argument is s2i --env argument value.
+# Other arguments are additional s2i options, like --env=FOO=bar.
 # The test function have available container ID in $cid_file, container output
 # in ${tmp_dir}/out, container stderr in ${tmp_dir}/err.
 do_test() {
     test_name="$1"
     test_function="$2"
-    test_environment="$3"
+    shift 2
+
+    # Old source-to-image 1.0.3 does not support multiple --env options.
+    # TODO: Remove ARGUMENTS conversion after dropping support 1.0.3.
+    local old_sti=0
+    if [[ "$(LC_ALL=C s2i help build 2>&1)" =~ \
+        'Specify an environment var NAME=VALUE,NAME2=VALUE2' ]]; then
+        old_sti=1
+    fi
+    local argument arguments environment
+    for argument in "$@"; do
+        if [ "$old_sti" == '1' -a "${argument:0:6}" == '--env=' ]; then
+            environment="${environment:+${environment},}${argument:6}"
+        else
+            arguments[${#arguments[*]}]="$argument"
+        fi
+    done
+    if [ -n "$environment" ]; then
+            arguments[${#arguments[*]}]="--env=${environment}"
+    fi
 
     info "Starting tests for ${test_name}."
 
@@ -221,7 +240,7 @@ do_test() {
 
     # Build and run the test application
     prepare
-    run_s2i_build $s2i_args $test_environment
+    run_s2i_build $s2i_args "${arguments[@]}"
     check_result $?
     run_test_application >"${tmp_dir}/out" 2>"${tmp_dir}/err" &
     wait_for_cid
@@ -292,7 +311,8 @@ test_4_function() {
     test_response '/path' 200 '<title>Web::Paste::Simple' && \
     test_response '/cpanfile' 200 'requires'
 }
-do_test 'psgi-variables' 'test_4_function' '--env=PSGI_FILE=./application2.psgi --env=PSGI_URI_PATH=/path'
+do_test 'psgi-variables' 'test_4_function' \
+    '--env=PSGI_FILE=./application2.psgi' '--env=PSGI_URI_PATH=/path'
 
 # Check httpd access_log flows to stdout, error_log to stdout.
 # TODO: send error_log to stderr after dropping support for broken

--- a/5.24/Dockerfile
+++ b/5.24/Dockerfile
@@ -1,0 +1,45 @@
+FROM openshift/base-centos7
+
+# This image provides a Perl 5.24 environment you can use to run your Perl applications.
+MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
+
+EXPOSE 8080
+
+# Image metadata
+ENV PERL_VERSION=5.24
+
+LABEL io.k8s.description="Platform for building and running Perl 5.24 applications" \
+      io.k8s.display-name="Apache 2.4 with mod_perl/5.24" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,perl,perl524"
+
+RUN yum install -y centos-release-scl && \
+    INSTALL_PKGS="rh-perl524 rh-perl524-perl-devel rh-perl524-mod_perl rh-perl524-perl-CPAN rh-perl524-perl-App-cpanminus" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Each language image can have 'contrib' a directory with extra files needed to
+# run and build the applications.
+COPY ./contrib/ /opt/app-root
+
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
+RUN mkdir -p /opt/app-root/etc/httpd.d && \
+    sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf  && \
+    chmod -R og+rwx /opt/rh/httpd24/root/var/run/httpd /opt/app-root/etc/httpd.d && \
+    chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root
+
+USER 1001
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/opt/app-root/etc/scl_enable \
+    ENV=/opt/app-root/etc/scl_enable \
+    PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/5.24/Dockerfile.rhel7
+++ b/5.24/Dockerfile.rhel7
@@ -1,0 +1,51 @@
+FROM rhscl/s2i-base-rhel7
+
+# This image provides a Perl 5.24 environment you can use to run your Perl applications.
+EXPOSE 8080
+
+# Image metadata
+ENV PERL_VERSION=5.24
+
+LABEL io.k8s.description="Platform for building and running Perl 5.24 applications" \
+      io.k8s.display-name="Apache 2.4 with mod_perl/5.24" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,perl,perl524"
+
+# Labels consumed by Red Hat build service
+LABEL Name="rhscl/perl-524-rhel7" \
+      BZComponent="rh-perl524-docker" \
+      Version="5.24" \
+      Release="1" \
+      Architecture="x86_64"
+
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    INSTALL_PKGS="rh-perl524 rh-perl524-perl-devel rh-perl524-mod_perl rh-perl524-perl-CPAN rh-perl524-perl-App-cpanminus" && \
+    yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Each language image can have 'contrib' a directory with extra files needed to
+# run and build the applications.
+COPY ./contrib/ /opt/app-root
+
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
+RUN mkdir -p /opt/app-root/etc/httpd.d && \
+    sed -i -f /opt/app-root/etc/httpdconf.sed /opt/rh/httpd24/root/etc/httpd/conf/httpd.conf  && \
+    chmod -R og+rwx /opt/rh/httpd24/root/var/run/httpd /opt/app-root/etc/httpd.d && \
+    chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root
+
+USER 1001
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/opt/app-root/etc/scl_enable \
+    ENV=/opt/app-root/etc/scl_enable \
+    PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/5.24/README.md
+++ b/5.24/README.md
@@ -1,0 +1,139 @@
+Perl Docker image
+=================
+
+This repository contains the source for building various versions of
+the Perl application as a reproducible Docker image using
+[source-to-image](https://github.com/openshift/source-to-image).
+Users can choose between RHEL and CentOS based builder images.
+The resulting image can be run using [Docker](http://docker.io).
+
+
+Usage
+---------------------
+To build a simple [perl-sample-app](https://github.com/openshift/s2i-perl/tree/master/5.24/test/sample-test-app) application,
+using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
+resulting image with [Docker](http://docker.io) execute:
+
+*  **For RHEL based image**
+    ```
+    $ s2i build https://github.com/openshift/s2i-perl.git --context-dir=5.24/test/sample-test-app/ rhscl/perl-524-rhel7 perl-sample-app
+    $ docker run -p 8080:8080 perl-sample-app
+    ```
+
+*  **For CentOS based image**
+    ```
+    $ s2i build https://github.com/openshift/s2i-perl.git --context-dir=5.24/test/sample-test-app/ centos/perl-524-centos7 perl-sample-app
+    $ docker run -p 8080:8080 perl-sample-app
+    ```
+
+**Accessing the application:**
+```
+$ curl 127.0.0.1:8080
+```
+
+
+Repository organization
+------------------------
+* **`<perl-version>`**
+
+    * **Dockerfile**
+
+        CentOS based Dockerfile.
+
+    * **Dockerfile.rhel7**
+
+        RHEL based Dockerfile. In order to perform build or test actions on this
+        Dockerfile you need to run the action on a properly subscribed RHEL machine.
+
+    * **`s2i/bin/`**
+
+        This folder contains scripts that are run by [S2I](https://github.com/openshift/source-to-image):
+
+        *   **assemble**
+
+            Used to install the sources into a location where the application
+            will be run and prepare the application for deployment (eg. installing
+            modules, etc.).
+            In order to install application dependencies, the application must contain a
+            `cpanfile` file, in which the user specifies the modules and their versions.
+            An example of a [cpanfile](https://github.com/openshift/s2i-perl/blob/master/5.24/test/sample-test-app/cpanfile) is available within our test application.
+
+            All files with `.cgi` and `.pl` extension are handled by mod_perl.
+            If exactly one file with `.psgi` extension exists in the top-level
+            directory, the mod_perl will be autoconfigured to execute the PSGI
+            application for any request URI path with Plack's mod_perl adaptor.
+
+        *   **run**
+
+            This script is responsible for running the application, using the
+            Apache web server.
+
+        *   **usage***
+
+            This script prints the usage of this image.
+
+    * **`contrib/`**
+
+        This folder contains a file with commonly used modules.
+
+    * **`test/`**
+
+        This folder contains the [S2I](https://github.com/openshift/source-to-image)
+        test framework.
+
+        * **`sample-test-app/`**
+
+            A simple Perl application used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+        * **run**
+
+            This script runs the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+
+Environment variables
+---------------------
+
+To set environment variables, you can place them as a key value pair into a `.sti/environment`
+file inside your source code repository.
+
+* **ENABLE_CPAN_TEST**
+
+    Allow the installation of all specified cpan packages and the running of their tests. The default value is `false`.
+
+* **CPAN_MIRROR**
+
+    This variable specifies a mirror URL which will used by cpanminus to install dependencies.
+    By default the URL is not specified.
+
+* **PERL_APACHE2_RELOAD**
+
+    Set this to "true" to enable automatic reloading of modified Perl modules.
+
+* **HTTPD_START_SERVERS**
+
+    The [StartServers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#startservers)
+    directive sets the number of child server processes created on startup. Default is 8.
+
+* **HTTPD_MAX_REQUEST_WORKERS**
+
+    Number of simultaneous requests that will be handled by Apache. The default
+    is 256, but it will be automatically lowered if memory is limited.
+
+* **PSGI_FILE**
+
+    Override PSGI application detection.
+
+    If the PSGI_FILE variable is set to empty value, no PSGI application will
+    be detected and mod_perl not be reconfigured.
+
+    If the PSGI_FILE variable is set and non-empty, it will define path to
+    the PSGI application file. No detection will be used.
+
+    If the PSGI_FILE variable does not exist, autodetection will be used:
+    If exactly one ./*.psgi file exists, mod_perl will be configured to
+    execute that file.
+
+* **PSGI_URI_PATH**
+
+    This variable overrides location URI path that is handled path the PSGI
+    application. Default value is "/".

--- a/5.24/cccp.yml
+++ b/5.24/cccp.yml
@@ -1,0 +1,3 @@
+# This is for the purpose of building this container on
+# the CentOS Container Pipeline.
+job-id: perl-524-centos7

--- a/5.24/contrib/etc/httpd.conf
+++ b/5.24/contrib/etc/httpd.conf
@@ -1,0 +1,17 @@
+LoadModule perl_module modules/mod_perl.so
+DirectoryIndex index.pl
+
+PerlSwitches -I./extlib/lib/perl5
+
+<Files ~ "\.(pl|cgi)$">
+    SetHandler perl-script
+    PerlResponseHandler ModPerl::PerlRun
+    Options +ExecCGI +SymLinksIfOwnerMatch
+    PerlSendHeader On
+</Files>
+
+<Directory "/opt/app-root/src">
+  Require all granted
+</Directory>
+
+IncludeOptional /opt/app-root/etc/httpd.d/*.conf

--- a/5.24/contrib/etc/httpd.d/50-mpm.conf.template
+++ b/5.24/contrib/etc/httpd.d/50-mpm.conf.template
@@ -1,0 +1,11 @@
+# This value should mirror what is set in MinSpareServers.
+StartServers            ${HTTPD_START_SERVERS}
+MinSpareServers         ${HTTPD_START_SERVERS}
+MaxSpareServers         ${HTTPD_MAX_SPARE_SERVERS}
+# The MaxRequestWorkers directive sets the limit on the number of
+# simultaneous requests that will be served.
+# The default value, when no cgroup limits are set is 256.
+MaxRequestWorkers       ${HTTPD_MAX_REQUEST_WORKERS}
+ServerLimit             ${HTTPD_MAX_REQUEST_WORKERS}
+MaxConnectionsPerChild  4000
+MaxKeepAliveRequests    100

--- a/5.24/contrib/etc/httpdconf.sed
+++ b/5.24/contrib/etc/httpdconf.sed
@@ -1,0 +1,7 @@
+s/^Listen 80/Listen 0.0.0.0:8080/
+s/^User apache/User default/
+s/^Group apache/Group root/
+s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/src"%
+s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
+s%^ErrorLog "logs/error_log"%ErrorLog "|/usr/bin/cat"%
+s%CustomLog "logs/access_log"%CustomLog "|/usr/bin/cat"%

--- a/5.24/contrib/etc/scl_enable
+++ b/5.24/contrib/etc/scl_enable
@@ -1,0 +1,6 @@
+# IMPORTANT: Do not add more content to this file unless you know what you are
+#            doing. This file is sourced everytime the shell session is opened.
+#
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable httpd24 rh-perl524

--- a/5.24/s2i/bin/assemble
+++ b/5.24/s2i/bin/assemble
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -e
+
+shopt -s dotglob
+echo "---> Installing application source ..."
+mv /tmp/src/* ./
+
+if [ -d ./cfg ]; then
+  echo "---> Copying configuration files..."
+  if [ "$(ls -A ./cfg/*.conf)" ]; then
+    cp -v ./cfg/*.conf /opt/app-root/etc/httpd.d/
+  fi
+fi
+
+# Allow for http proxy to be specified in uppercase
+if [[ -n "${HTTP_PROXY:-}" && -z "${http_proxy:-}" ]]; then
+  export http_proxy=$HTTP_PROXY
+fi
+
+export CPAN_MIRROR=${CPAN_MIRROR:-""}
+
+MIRROR_ARGS=""
+
+if [ -n "$CPAN_MIRROR" ]; then
+  MIRROR_ARGS="--mirror $CPAN_MIRROR"
+fi
+
+# Don't test installed Perl modules by default
+if [ "${ENABLE_CPAN_TEST}" = true ]; then
+  export ENABLE_CPAN_TEST=""
+else
+  export ENABLE_CPAN_TEST="--notest"
+fi
+
+# Configure mod_perl for PSGI.
+# If PSGI_FILE variable is set but empty, skip it.
+# If PSGI_FILE is set and non-empty, use it.
+# If PSGI_FILE does not exist, check if exactly one ./*.psgi file exists and
+# use that file.
+# If PSGI_URI_PATH variable has a value, use it as a location. Default is "/".
+if [ ! -v PSGI_FILE ]; then
+    PSGI_FILE=$(find -maxdepth 1 -name '*.psgi' -type f)
+fi
+PSGI_FILE_NUMBER=$(printf '%s' "$PSGI_FILE" | wc -l)
+if [ -n "$PSGI_FILE" -a "$PSGI_FILE_NUMBER" -eq 0 ]; then
+    echo "---> PSGI application found in $PSGI_FILE"
+    cat >> cpanfile <<"EOF"
+requires 'Plack::Handler::Apache2';
+EOF
+    # XXX: Escape PSGI_FILE value against httpd control characters
+    PSGI_FILE=$(printf '%s' "$PSGI_FILE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+    cat > /opt/app-root/etc/httpd.d/40-psgi.conf <<EOF
+<Location ${PSGI_URI_PATH:=/}>
+    SetHandler perl-script
+    PerlResponseHandler Plack::Handler::Apache2
+    PerlSetVar psgi_app "$PSGI_FILE"
+</Location>
+EOF
+elif [ "$PSGI_FILE_NUMBER" -gt 0 ]; then
+    echo "---> Multiple PSGI applications found:"
+    printf '%s' "$PSGI_FILE"
+    echo "---> Skipping PSGI autoconfiguration!"
+fi
+
+# Installing dependencies with cpanfile
+if [ -f "cpanfile" ]; then
+  echo "---> Installing modules from cpanfile ..."
+  cpanm $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib Module::CoreList
+  cpanm $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib --installdeps .
+else
+  echo "---> No cpanfile found, nothing to install"
+fi
+
+# Fix source directory permissions
+fix-permissions ./

--- a/5.24/s2i/bin/run
+++ b/5.24/s2i/bin/run
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+# CPAN can install scripts. They should be available from mod_perl too.
+export PATH=${PATH}:/opt/app-root/src/extlib/bin
+# And we have to set Perl include path too because mod_perl's PerlSwitches
+# does not apply to them.
+export PERL5LIB=/opt/app-root/src/extlib/lib/perl5
+
+# Warning: Please note that this will pass all environment variables available within the
+# container to mod_perl by means of PerlPassEnv in the env.conf file
+if [ ! -f /opt/app-root/etc/httpd.d/env.conf ]; then
+  env | awk -F'=' '{print "PerlPassEnv "$1}' > /opt/app-root/etc/httpd.d/env.conf
+fi
+
+# Enable automatic reloading. This can be useful for debugging an application.
+PERL_APACHE2_RELOAD=${PERL_APACHE2_RELOAD:-}
+if [[ "${PERL_APACHE2_RELOAD,,}" == "true" ]]; then
+  cat > /opt/app-root/etc/httpd.d/50-autoreload.conf <<EOF
+PerlModule Apache2::Reload
+PerlInitHandler Apache2::Reload
+EOF
+fi
+
+export_vars=$(cgroup-limits) ; export $export_vars
+
+# Validate server limit option
+if [[ ! "${HTTPD_MAX_REQUEST_WORKERS:-1}" =~ ^[1-9][0-9]*$ || "${HTTPD_MAX_REQUEST_WORKERS:-1}" -gt 20000 ]]; then
+  echo "HTTPD_MAX_REQUEST_WORKERS needs be an integer between 1 and 20000"
+  exit 1
+fi
+
+# If there is no server limit specified, try to guess the best value
+if [ -z "${HTTPD_MAX_REQUEST_WORKERS:-}" ]; then
+  MAX_SERVER_LIMIT=$(((MEMORY_LIMIT_IN_BYTES/1024/1024 - 30) / 7))
+  MAX_SERVER_LIMIT=$((MAX_SERVER_LIMIT > 0 ? MAX_SERVER_LIMIT : 1))
+  export HTTPD_MAX_REQUEST_WORKERS=$((MAX_SERVER_LIMIT > 256 ? 256 : MAX_SERVER_LIMIT))
+fi
+
+export HTTPD_START_SERVERS=${HTTPD_START_SERVERS:-8}
+export HTTPD_MAX_SPARE_SERVERS=$((HTTPD_START_SERVERS+10))
+
+envsubst < /opt/app-root/etc/httpd.d/50-mpm.conf.template > /opt/app-root/etc/httpd.d/50-mpm.conf
+
+exec httpd -C 'Include /opt/app-root/etc/httpd.conf' -D FOREGROUND

--- a/5.24/s2i/bin/usage
+++ b/5.24/s2i/bin/usage
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=centos
+[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
+
+cat <<EOF
+This is a S2I ${IMAGE_DESCRIPTION} ${DISTRO} base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+s2i build https://github.com/openshift/s2i-perl.git --context-dir=5.24/test/sample-test-app/ ${NAMESPACE}/perl-524-${DISTRO}7 perl-sample-app
+
+You can then run the resulting image via:
+docker run -p 8080:8080 perl-sample-app
+EOF

--- a/5.24/test/binpath/cpanfile
+++ b/5.24/test/binpath/cpanfile
@@ -1,0 +1,1 @@
+requires 'Net::IP';

--- a/5.24/test/binpath/index.pl
+++ b/5.24/test/binpath/index.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/perl
+print "Content-type: text/plain\n\n";
+my $output = `ipcount 2>&1`;
+if (!defined $output) {
+    die "No output from `ipcount' command";
+}
+print $output;

--- a/5.24/test/psgi-variables/application1.psgi
+++ b/5.24/test/psgi-variables/application1.psgi
@@ -1,0 +1,1 @@
+die "This should not be picked up.";

--- a/5.24/test/psgi-variables/application2.psgi
+++ b/5.24/test/psgi-variables/application2.psgi
@@ -1,0 +1,3 @@
+#!/usr/bin/env plackup
+use Web::Paste::Simple;
+Web::Paste::Simple->new->app;

--- a/5.24/test/psgi-variables/cpanfile
+++ b/5.24/test/psgi-variables/cpanfile
@@ -1,0 +1,1 @@
+requires 'Web::Paste::Simple';

--- a/5.24/test/psgi/application.psgi
+++ b/5.24/test/psgi/application.psgi
@@ -1,0 +1,3 @@
+#!/usr/bin/env plackup
+use Web::Paste::Simple;
+Web::Paste::Simple->new->app;

--- a/5.24/test/psgi/cpanfile
+++ b/5.24/test/psgi/cpanfile
@@ -1,0 +1,1 @@
+requires 'Web::Paste::Simple';

--- a/5.24/test/run
+++ b/5.24/test/run
@@ -1,0 +1,327 @@
+#!/bin/bash
+#
+# The 'run' performs a simple test that verifies that S2I image.
+# The main focus here is to exercise the S2I scripts.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+IMAGE_NAME=${IMAGE_NAME-openshift/perl-524-centos-candidate}
+
+# TODO: Make command compatible for Mac users
+test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
+image_dir=$(readlink -zf ${test_dir}/..)
+
+# TODO: This should be part of the image metadata
+test_port=8080
+
+info() {
+  echo -e "\n\e[1m[INFO] $@...\e[0m\n"
+}
+
+image_exists() {
+  docker inspect $1 &>/dev/null
+}
+
+container_exists() {
+  image_exists $(cat $cid_file)
+}
+
+container_ip() {
+  docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file)
+}
+
+run_s2i_build() {
+  s2i build "$@" file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+}
+
+prepare() {
+  if ! image_exists ${IMAGE_NAME}; then
+    echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
+    exit 1
+  fi
+  # TODO: S2I build require the application is a valid 'GIT' repository, we
+  # should remove this restriction in the future when a file:// is used.
+  info "Build the test application image"
+  pushd ${test_dir}/${test_name} >/dev/null
+  git init
+  git config user.email "build@localhost" && git config user.name "builder"
+  git add -A && git commit -m "Sample commit"
+  popd >/dev/null
+}
+
+run_test_application() {
+  docker run --user=100001 --rm --cidfile=${cid_file} -p ${test_port} ${IMAGE_NAME}-testapp
+}
+
+cleanup_test_app() {
+  info "Cleaning up the test application"
+  if [ -f $cid_file ]; then
+    if container_exists; then
+      docker stop $(cat $cid_file)
+      docker rm $(cat $cid_file)
+    fi
+    rm $cid_file
+  fi
+}
+
+cleanup() {
+  info "Cleaning up the test application image"
+  if image_exists ${IMAGE_NAME}-testapp; then
+    docker rmi -f ${IMAGE_NAME}-testapp
+  fi
+  rm -rf ${test_dir}/${test_name}/.git
+}
+
+check_result() {
+  local result="$1"
+  if [[ "$result" != "0" ]]; then
+    info "TEST FAILED (${result})"
+    cleanup
+    exit $result
+  fi
+}
+
+wait_for_cid() {
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  info "Waiting for application container to start"
+  while [ $attempt -le $max_attempts ]; do
+    [ -f $cid_file ] && [ -s $cid_file ] && break
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+}
+
+test_s2i_usage() {
+  info "Testing 's2i usage'"
+  s2i usage ${s2i_args} ${IMAGE_NAME} &>/dev/null
+}
+
+test_docker_run_usage() {
+  info "Testing 'docker run' usage"
+  docker run ${IMAGE_NAME} &>/dev/null
+}
+
+test_scl_usage() {
+  local run_cmd="$1"
+  local expected="$2"
+
+  info "Testing the image SCL enable"
+  out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}")
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(cat ${cid_file}) /bin/sh -ic "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+}
+
+# Perform GET request to the application container.
+# First argument is request URI path.
+# Second argument is expected HTTP response code.
+# Third argument is PCRE regular expression that must match the response body.
+test_response() {
+  local uri_path="$1"
+  local expected_code="$2"
+  local body_regexp="$3"
+
+  local url="http://$(container_ip):${test_port}${uri_path}"
+  info "Testing the HTTP response for <${url}>"
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  while [ $attempt -le $max_attempts ]; do
+    response=$(curl -s -w '%{http_code}' "${url}")
+    status=$?
+    if [ $status -eq 0 ]; then
+      response_code=$(printf '%s' "$response" | tail -c 3)
+      response_body=$(printf '%s' "$response" | head -c -3)
+      if [ "$response_code" -eq "$expected_code" ]; then
+        result=0
+      fi
+      printf '%s' "$response_body" | grep -qP -e "$body_regexp" || result=1;
+      break
+    fi
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+  return $result
+}
+
+# Match PCRE regular expression against container standard output.
+# First argument is the PCRE regular expression.
+# It expects standard output in ${tmp_dir}/out file.
+test_stdout() {
+  local regexp="$1"
+  local output="${tmp_dir}/out"
+  info "Testing the container standard output for /${regexp}/"
+  grep -qP -e "$regexp" "$output";
+}
+
+# Match PCRE regular expression against container standard error output.
+# First argument is the PCRE regular expression.
+# It expects error output in ${tmp_dir}/err file.
+test_stderr() {
+  local regexp="$1"
+  local output="${tmp_dir}/err"
+  info "Testing the container error output for /${regexp}/"
+  grep -qP -e "$regexp" "$output";
+}
+
+test_connection() {
+    test_response '/' 200 ''
+}
+
+test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_scl_usage "perl --version" "v5.24.0"
+  check_result $?
+
+  test_connection
+  check_result $?
+  cleanup_test_app
+}
+
+# Build application, run it, perform test function, clean up.
+# First argument is directory name.
+# Second argument is function that expects running application. The function
+# must return (or terminate with) non-zero value to report an failure,
+# 0 otherwise.
+# Other arguments are additional s2i options, like --env=FOO=bar.
+# The test function have available container ID in $cid_file, container output
+# in ${tmp_dir}/out, container stderr in ${tmp_dir}/err.
+do_test() {
+    test_name="$1"
+    test_function="$2"
+    shift 2
+
+    # Old source-to-image 1.0.3 does not support multiple --env options.
+    # TODO: Remove ARGUMENTS conversion after dropping support 1.0.3.
+    local old_sti=0
+    if [[ "$(LC_ALL=C s2i help build 2>&1)" =~ \
+        'Specify an environment var NAME=VALUE,NAME2=VALUE2' ]]; then
+        old_sti=1
+    fi
+    local argument arguments environment
+    for argument in "$@"; do
+        if [ "$old_sti" == '1' -a "${argument:0:6}" == '--env=' ]; then
+            environment="${environment:+${environment},}${argument:6}"
+        else
+            arguments[${#arguments[*]}]="$argument"
+        fi
+    done
+    if [ -n "$environment" ]; then
+            arguments[${#arguments[*]}]="--env=${environment}"
+    fi
+
+    info "Starting tests for ${test_name}."
+
+    tmp_dir=$(mktemp -d)
+    check_result $?
+    cid_file="${tmp_dir}/cid"
+    s2i_args="--force-pull=false"
+
+    # Build and run the test application
+    prepare
+    run_s2i_build $s2i_args "${arguments[@]}"
+    check_result $?
+    run_test_application >"${tmp_dir}/out" 2>"${tmp_dir}/err" &
+    wait_for_cid
+
+    # Perform user-supplied test function
+    $test_function;
+    check_result $?
+
+    # Terminate the test application and clean up
+    cleanup_test_app
+    cleanup
+    rm -rf "$tmp_dir"
+    info "All tests for the ${test_name} finished successfully."
+}
+
+
+# List of tests to execute:
+
+# This is original test that does more things like s2i API checks. Other tests
+# executed by do_test() will not repeat these checks.
+test_1() {
+    test_name='sample-test-app'
+    info "Starting tests for ${test_name}"
+
+    cid_file=$(mktemp -u --suffix=.cid)
+
+    # Since we built the candidate image locally, we don't want S2I attempt to pull
+    # it from Docker hub
+    s2i_args="--force-pull=false"
+
+    prepare
+    run_s2i_build $s2i_args
+    check_result $?
+
+    # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
+    test_s2i_usage
+    check_result $?
+
+    # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
+    test_docker_run_usage
+    check_result $?
+
+    # Test application with default UID
+    test_application
+
+    # Test application with random UID
+    CONTAINER_ARGS="-u 12345" test_application
+
+    info "All tests for the ${test_name} finished successfully."
+    cleanup
+}
+test_1
+
+# Check scripts installed from CPAN are available to the application.
+test_2_function() {
+    test_response '/' 200 'Usage'
+}
+do_test 'binpath' 'test_2_function'
+
+# Check a single PSGI application is recognized a mod_perl is autoconfigured.
+test_3_function() {
+    test_response '/' 200 '<title>Web::Paste::Simple'
+}
+do_test 'psgi' 'test_3_function'
+
+# Check variables can select a PSGI application and set URI path.
+test_4_function() {
+    test_response '/path' 200 '<title>Web::Paste::Simple' && \
+    test_response '/cpanfile' 200 'requires'
+}
+do_test 'psgi-variables' 'test_4_function' \
+    '--env=PSGI_FILE=./application2.psgi' '--env=PSGI_URI_PATH=/path'
+
+# Check httpd access_log flows to stdout, error_log to stdout.
+# TODO: send error_log to stderr after dropping support for broken
+# docker < 1.9.
+test_5_function() {
+    test_response '/' 200 'Text in HTTP body' && \
+    test_stdout '"GET /[^"]*" 200 ' && \
+    test_stdout 'Warning on stderr'
+}
+do_test 'warningonstderr' 'test_5_function'
+
+info "All tests finished successfully."

--- a/5.24/test/sample-test-app/cpanfile
+++ b/5.24/test/sample-test-app/cpanfile
@@ -1,0 +1,1 @@
+requires 'Math::Round', '== 0.06';

--- a/5.24/test/sample-test-app/index.pl
+++ b/5.24/test/sample-test-app/index.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+
+use Math::Round;
+
+round(10.2) == 10 || die "round(10.2) != 10";
+
+print "Content-type: text/html\n\n";
+print <<EOF
+<html>
+<head><title>Everything is OK</title></head>
+<body>
+Everything is fine.
+</body>
+</html>
+EOF
+;

--- a/5.24/test/warningonstderr/index.pl
+++ b/5.24/test/warningonstderr/index.pl
@@ -1,0 +1,4 @@
+#!/usr/bin/perl
+print "Content-type: text/plain\n\n";
+warn "Warning on stderr\n";
+print "Text in HTTP body\n";

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in hack/build.sh.
 BASE_IMAGE_NAME = perl
-VERSIONS = 5.16 5.20
+VERSIONS = 5.16 5.20 5.24
 OPENSHIFT_NAMESPACES = 5.16
 
 # Include common Makefile code.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Variables are documented in hack/build.sh.
 BASE_IMAGE_NAME = perl
-VERSIONS = 5.16 5.20 5.24
+# 5.24 disabled because CentOS is missing rh-perl524 repository
+VERSIONS = 5.16 5.20
 OPENSHIFT_NAMESPACES = 5.16
 
 # Include common Makefile code.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Versions
 Perl versions currently provided are:
 * perl-5.16
 * perl-5.20
+* perl-5.24
 
 RHEL versions currently supported are:
 * RHEL7
@@ -65,6 +66,9 @@ see [usage documentation](5.16/README.md).
 
 For information about usage of Dockerfile for Perl 5.20,
 see [usage documentation](5.20/README.md).
+
+For information about usage of Dockerfile for Perl 5.24,
+see [usage documentation](5.24/README.md).
 
 
 Test


### PR DESCRIPTION
This patchset adds support for rh-perl524 collection. It adds support for source-to-image-1.0.3 as discussed on https://github.com/sclorg/s2i-perl-container/pull/99 to work on Fedora 23. Then it adds support for rh-perl524 collection and finally it disables the collection in the top-level Makefile because CentOS is still missing the rh-perl524 packages (not to break automated CentOS tests). The last commit will be reverted once the collection appears in the CentOS.
