### PR TITLE
Fix using subscription in container

### DIFF
--- a/5.16/Dockerfile.rhel7
+++ b/5.16/Dockerfile.rhel7
@@ -20,7 +20,10 @@ LABEL BZComponent="openshift-sti-perl-docker" \
       Architecture="x86_64"
 
 # TODO: Cleanup cpanp cache after cpanminus is installed?
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="httpd24 perl516 perl516-mod_perl perl516-perl-CPANPLUS" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/5.20/Dockerfile.rhel7
+++ b/5.20/Dockerfile.rhel7
@@ -19,7 +19,10 @@ LABEL Name="rhscl/perl-520-rhel7" \
       Architecture="x86_64"
 
 # TODO: Cleanup cpanp cache after cpanminus is installed?
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="rh-perl520 rh-perl520-perl-devel rh-perl520-mod_perl rh-perl520-perl-CPAN" && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \


### PR DESCRIPTION
Enabling host repositories didn't work with docker 1.10 and newer inside OpenStack. It was fixed in latest rhel7 base release, so using 'rhel7' base image is required for RHEL CI. Postgresql PR - sclorg/postgresql-container#150

Also to enable repositories inside container running 'yum' first is required - see https://access.redhat.com/solutions/1443553 . Similar to sclorg/s2i-base-container#99 .


@hhorak @bparees Please take a look and merge.