### PR TITLE
Enable rh-nodejs6, so users can use npm for installing JavaScript stuff

### DIFF
--- a/5.20/root/opt/app-root/etc/scl_enable
+++ b/5.20/root/opt/app-root/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable httpd24 rh-perl520
+source scl_source enable httpd24 rh-perl520 rh-nodejs6

--- a/5.24/root/opt/app-root/etc/scl_enable
+++ b/5.24/root/opt/app-root/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable httpd24 rh-perl524
+source scl_source enable httpd24 rh-perl524 rh-nodejs6


### PR DESCRIPTION
Similarly to https://github.com/sclorg/s2i-python-container/pull/209