### PR TITLE
imagestream definition for rhel based perl 5.26 on ppc64le

### DIFF
--- a/imagestreams/perl-rhel7-ppc64le.json
+++ b/imagestreams/perl-rhel7-ppc64le.json
@@ -1,0 +1,54 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "perl_ppc64le",
+    "annotations": {
+      "openshift.io/display-name": "Perl (ppc64le)"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Perl (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Perl applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Perl available on OpenShift, including major versions updates.",
+          "iconClass": "icon-perl",
+          "tags": "builder,perl",
+          "supports":"perl",
+          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "5.26"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "5.26",
+        "annotations": {
+          "openshift.io/display-name": "Perl 5.26 (ppc64le)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Perl 5.26 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
+          "iconClass": "icon-perl",
+          "importer.image.openshift.io/prefer-arch": "ppc64le",
+          "tags": "builder,perl",
+          "supports":"perl_ppc64le:5.26,perl_ppc64le",
+          "version": "5.26",
+          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/rhscl/perl-526-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adding rhel7 based perl 5.26 imagestream that will support ppc64le.