### PR TITLE
Update common submodule and fix tests

### DIFF
--- a/5.24/test/run-openshift
+++ b/5.24/test/run-openshift
@@ -29,5 +29,5 @@ ct_os_test_template_app ${IMAGE_NAME} \
                         ${THISDIR}/sample-test-app.json \
                         perl \
                         "Everything is OK" \
-                        8080 http 200 "-p SOURCE_REPOSITORY_REF=staging -p VERSION=${VERSION}"
+                        8080 http 200 "-p SOURCE_REPOSITORY_REF=staging -p VERSION=${VERSION} -p NAME=perl-testing"
 

--- a/5.26/test/run-openshift
+++ b/5.26/test/run-openshift
@@ -29,5 +29,5 @@ ct_os_test_template_app ${IMAGE_NAME} \
                         ${THISDIR}/sample-test-app.json \
                         perl \
                         "Everything is OK" \
-                        8080 http 200 "-p SOURCE_REPOSITORY_REF=staging -p VERSION=${VERSION}"
+                        8080 http 200 "-p SOURCE_REPOSITORY_REF=staging -p VERSION=${VERSION} -p NAME=perl-testing"
 


### PR DESCRIPTION
It is necessary to define `NAME` variable, so we don't need to guess names of the services.