### PR TITLE
OKD rebranding and sclorg move

### DIFF
--- a/5.20/test/run-openshift
+++ b/5.20/test/run-openshift
@@ -22,7 +22,7 @@ ct_os_cluster_up
 # so we can test changes in that example app that are done as part of the PR
 ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/s2i-perl-container.git" ${VERSION}/test/sample-test-app "Everything is OK"
 
-ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/openshift/dancer-ex.git" . 'Welcome to your Dancer application on OpenShift'
+ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/dancer-ex.git" . 'Welcome to your Dancer application on OpenShift'
 
 # TODO: this was not working because the referenced example dir was added as part of this commit
 ct_os_test_template_app ${IMAGE_NAME} \

--- a/5.24/test/run-openshift
+++ b/5.24/test/run-openshift
@@ -22,7 +22,7 @@ ct_os_cluster_up
 # so we can test changes in that example app that are done as part of the PR
 ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/s2i-perl-container.git" ${VERSION}/test/sample-test-app "Everything is OK"
 
-ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/openshift/dancer-ex.git" . 'Welcome to your Dancer application on OpenShift'
+ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/dancer-ex.git" . 'Welcome to your Dancer application on OpenShift'
 
 # TODO: this was not working because the referenced example dir was added as part of this commit
 ct_os_test_template_app ${IMAGE_NAME} \

--- a/5.26/test/run-openshift
+++ b/5.26/test/run-openshift
@@ -22,7 +22,7 @@ ct_os_cluster_up
 # so we can test changes in that example app that are done as part of the PR
 ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/s2i-perl-container.git" ${VERSION}/test/sample-test-app "Everything is OK"
 
-ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/openshift/dancer-ex.git" . 'Welcome to your Dancer application on OpenShift'
+ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/dancer-ex.git" . 'Welcome to your Dancer application on OpenShift'
 
 # TODO: this was not working because the referenced example dir was added as part of this commit
 ct_os_test_template_app ${IMAGE_NAME} \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Users can choose between RHEL and CentOS based builder images.
 The resulting image can be run using [Docker](http://docker.io).
 
 For more information about using these images with OpenShift, please see the
-official [OpenShift Origin documentation](https://docs.openshift.org/latest/using_images/s2i_images/perl.html).
+official [OpenShift Origin documentation](https://docs.okd.io/latest/using_images/s2i_images/perl.html).
 
 For more information about contributing, see
 [the Contribution Guidelines](https://github.com/sclorg/welcome/blob/master/contribution.md).

--- a/imagestreams/perl-centos7.json
+++ b/imagestreams/perl-centos7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-perl",
           "tags": "builder,perl",
           "supports":"perl",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,builder,perl",
           "supports":"perl:5.16,perl",
           "version": "5.16",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,perl",
           "supports":"perl:5.20,perl",
           "version": "5.20",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,perl",
           "supports":"perl:5.24,perl",
           "version": "5.24",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -98,7 +98,7 @@
           "tags": "builder,perl",
           "supports":"perl:5.26,perl",
           "version": "5.26",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/perl-rhel7-ppc64le.json
+++ b/imagestreams/perl-rhel7-ppc64le.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-perl",
           "tags": "builder,perl",
           "supports":"perl",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -39,7 +39,7 @@
           "tags": "builder,perl",
           "supports":"perl_ppc64le:5.26,perl_ppc64le",
           "version": "5.26",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/perl-rhel7.json
+++ b/imagestreams/perl-rhel7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-perl",
           "tags": "builder,perl",
           "supports":"perl",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,builder,perl",
           "supports":"perl:5.16,perl",
           "version": "5.16",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,perl",
           "supports":"perl:5.20,perl",
           "version": "5.20",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,perl",
           "supports":"perl:5.24,perl",
           "version": "5.24",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -98,7 +98,7 @@
           "tags": "builder,perl",
           "supports":"perl:5.26,perl",
           "version": "5.26",
-          "sampleRepo": "https://github.com/openshift/dancer-ex.git"
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",


### PR DESCRIPTION
docs.openshift.org to docs.okd.io
github.com/openshift/dancer-ex to github.com/sclorg/dancer-ex