### PR TITLE
Add Perl 5.26 with mod_fcgid for RHEL-8 Beta

### DIFF
--- a/5.26-mod_fcgid/Dockerfile.rhel8
+++ b/5.26-mod_fcgid/Dockerfile.rhel8
@@ -1,0 +1,64 @@
+FROM rhel8/s2i-base:1
+
+# This image provides a Perl 5.26 environment you can use to run your Perl applications.
+
+EXPOSE 8080
+
+# Image metadata
+ENV PERL_VERSION=5.26 \
+    PERL_SHORT_VER=526 \
+    NAME=perl
+
+ENV SUMMARY="Platform for building and running Perl $PERL_VERSION applications" \
+    DESCRIPTION="Perl $PERL_VERSION available as container is a base platform for \
+building and running various Perl $PERL_VERSION applications and frameworks. \
+Perl is a high-level programming language with roots in C, sed, awk and shell scripting. \
+Perl is good at handling processes and files, and is especially good at handling text. \
+Perl's hallmarks are practicality and efficiency. While it is used to do a lot of \
+different things, Perl's most common applications are system administration utilities \
+and web programming."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Apache 2.4 with mod_fcgid and Perl $PERL_VERSION" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,${NAME},${NAME}${PERL_SHORT_VER}","${NAME}-${PERL_SHORT_VER}" \
+      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
+      io.s2i.scripts-url="image:///usr/libexec/s2i" \
+      name="rhel8/${NAME}-${PERL_SHORT_VER}" \
+      com.redhat.component="${NAME}-${PERL_SHORT_VER}-container" \
+      version="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \
+      usage="s2i build <SOURCE-REPOSITORY> rhel8/${NAME}-${PERL_SHORT_VER}:latest <APP-NAME>"
+
+# perl-FCGI module is missing a default stream
+RUN yum -y module enable perl-FCGI:0.78
+
+RUN INSTALL_PKGS="perl perl-devel mod_fcgid perl-App-cpanminus perl-FCGI patch" && \
+    yum -y module enable perl:$PERL_VERSION && \
+    yum -y --allowerasing distrosync && \
+    yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
+RUN mkdir -p ${APP_ROOT}/etc/httpd.d && \
+    sed -i -f ${APP_ROOT}/etc/httpdconf.sed /etc/httpd/conf/httpd.conf && \
+    chmod -R og+rwx /var/run/httpd /run/mod_fcgid ${APP_ROOT}/etc/httpd.d && \
+    chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
+    rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/5.26-mod_fcgid/README.md
+++ b/5.26-mod_fcgid/README.md
@@ -1,0 +1,101 @@
+Perl 5.26 container image
+=========================
+
+This container image includes Perl 5.26 as a [S2I](https://github.com/openshift/source-to-image) base image for your Perl 5.26 applications.
+Users can choose between RHEL and CentOS based builder images.
+The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhel8/perl-526)
+as registry.access.redhat.com/rhel8/perl-526.
+The CentOS image is then available on [Docker Hub](https://hub.docker.com/r/centos/perl-526-centos8/)
+as centos/perl-526-centos8. 
+The resulting image can be run using [Docker](http://docker.io).
+
+Description
+-----------
+
+Perl 5.26 available as container is a base platform for 
+building and running various Perl 5.26 applications and frameworks. 
+Perl is a high-level programming language with roots in C, sed, awk and shell scripting. 
+Perl is good at handling processes and files, and is especially good at handling text. 
+Perl's hallmarks are practicality and efficiency. While it is used to do a lot of 
+different things, Perl's most common applications are system administration utilities 
+and web programming.
+
+This container image includes an npm utility, so users can use it to install JavaScript
+modules for their web applications. There is no guarantee for any specific npm or nodejs
+version, that is included in the image; those versions can be changed anytime and
+the nodejs itself is included just to make the npm work.
+
+Usage
+---------------------
+To build a simple [perl-sample-app](https://github.com/sclorg/s2i-perl-container/tree/master/5.26/test/sample-test-app) application,
+using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
+resulting image with [Docker](http://docker.io) execute:
+
+*  **For RHEL based image**
+    ```
+    $ s2i build https://github.com/sclorg/s2i-perl-container.git --context-dir=5.26/test/sample-test-app/ rhel8/perl-526 perl-sample-app
+    $ docker run -p 8080:8080 perl-sample-app
+    ```
+
+*  **For CentOS based image**
+    ```
+    $ s2i build https://github.com/sclorg/s2i-perl-container.git --context-dir=5.26/test/sample-test-app/ centos/perl-526-centos8 perl-sample-app
+    $ docker run -p 8080:8080 perl-sample-app
+    ```
+
+**Accessing the application:**
+```
+$ curl 127.0.0.1:8080
+```
+
+Environment variables
+---------------------
+
+To set environment variables, you can place them as a key value pair into a `.sti/environment`
+file inside your source code repository.
+
+* **ENABLE_CPAN_TEST**
+
+    Allow the installation of all specified cpan packages and the running of their tests. The default value is `false`.
+
+* **CPAN_MIRROR**
+
+    This variable specifies a mirror URL which will used by cpanminus to install dependencies.
+    By default the URL is not specified.
+
+* **HTTPD_START_SERVERS**
+
+    The [StartServers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#startservers)
+    directive sets the number of child server processes created on startup. Default is 8.
+
+* **HTTPD_MAX_REQUEST_WORKERS**
+
+    Number of simultaneous requests that will be handled by Apache httpd. The default
+    is 256, but it will be automatically lowered if memory is limited.
+
+* **PSGI_FILE**
+
+    Override PSGI application detection.
+
+    If the PSGI_FILE variable is set to an empty value, no PSGI application will
+    be detected and mod_fcgid will not be reconfigured.
+
+    If the PSGI_FILE variable is set and non-empty, it will define path to
+    a PSGI application file and mod_fcgid will be configured to execute that
+    file.
+
+    If the PSGI_FILE variable does not exist, autodetection will be used:
+    If exactly one ./*.psgi file exists, mod_fcgid will be configured to
+    execute that file.
+
+* **PSGI_URI_PATH**
+
+    This variable overrides location URI path that is handled path the PSGI
+    application. Default value is "/".
+
+
+See also
+--------
+Dockerfile and other sources are available on https://github.com/sclorg/s2i-perl-container.
+In that repository you also can find another versions of Perl environment Dockerfiles.
+Dockerfile for CentOS is called Dockerfile, Dockerfile for RHEL is called Dockerfile.rhel8.

--- a/5.26-mod_fcgid/content_sets.yml
+++ b/5.26-mod_fcgid/content_sets.yml
@@ -1,0 +1,21 @@
+# This is a file defining which content sets are needed to update content in 
+# this image. Data provided here helps determine which images are vulnerable to
+# specific CVEs. Generally you should only need to update this file when:
+#    1. You start depending on new product
+#    2. You are preparing new product release and your content sets will change
+---
+x86_64:
+- rhel-8-for-x86_64-baseos-beta-rpms
+- rhel-8-for-x86_64-appstream-beta-rpms
+
+ppc64le:
+- rhel-8-for-ppc64le-baseos-beta-rpms
+- rhel-8-for-ppc64le-appstream-beta-rpms
+
+s390x:
+- rhel-8-for-s390x-baseos-beta-rpms
+- rhel-8-for-s390x-appstream-beta-rpms
+
+aarch64:
+- rhel-8-for-aarch64-baseos-beta-rpms
+- rhel-8-for-aarch64-appstream-beta-rpms

--- a/5.26-mod_fcgid/help.md
+++ b/5.26-mod_fcgid/help.md
@@ -1,0 +1,101 @@
+Perl 5.26 container image
+=========================
+
+This container image includes Perl 5.26 as a [S2I](https://github.com/openshift/source-to-image) base image for your Perl 5.26 applications.
+Users can choose between RHEL and CentOS based builder images.
+The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhel8/perl-526)
+as registry.access.redhat.com/rhel8/perl-526.
+The CentOS image is then available on [Docker Hub](https://hub.docker.com/r/centos/perl-526-centos8/)
+as centos/perl-526-centos8. 
+The resulting image can be run using [Docker](http://docker.io).
+
+Description
+-----------
+
+Perl 5.26 available as container is a base platform for 
+building and running various Perl 5.26 applications and frameworks. 
+Perl is a high-level programming language with roots in C, sed, awk and shell scripting. 
+Perl is good at handling processes and files, and is especially good at handling text. 
+Perl's hallmarks are practicality and efficiency. While it is used to do a lot of 
+different things, Perl's most common applications are system administration utilities 
+and web programming.
+
+This container image includes an npm utility, so users can use it to install JavaScript
+modules for their web applications. There is no guarantee for any specific npm or nodejs
+version, that is included in the image; those versions can be changed anytime and
+the nodejs itself is included just to make the npm work.
+
+Usage
+---------------------
+To build a simple [perl-sample-app](https://github.com/sclorg/s2i-perl-container/tree/master/5.26/test/sample-test-app) application,
+using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
+resulting image with [Docker](http://docker.io) execute:
+
+*  **For RHEL based image**
+    ```
+    $ s2i build https://github.com/sclorg/s2i-perl-container.git --context-dir=5.26/test/sample-test-app/ rhel8/perl-526 perl-sample-app
+    $ docker run -p 8080:8080 perl-sample-app
+    ```
+
+*  **For CentOS based image**
+    ```
+    $ s2i build https://github.com/sclorg/s2i-perl-container.git --context-dir=5.26/test/sample-test-app/ centos/perl-526-centos8 perl-sample-app
+    $ docker run -p 8080:8080 perl-sample-app
+    ```
+
+**Accessing the application:**
+```
+$ curl 127.0.0.1:8080
+```
+
+Environment variables
+---------------------
+
+To set environment variables, you can place them as a key value pair into a `.sti/environment`
+file inside your source code repository.
+
+* **ENABLE_CPAN_TEST**
+
+    Allow the installation of all specified cpan packages and the running of their tests. The default value is `false`.
+
+* **CPAN_MIRROR**
+
+    This variable specifies a mirror URL which will used by cpanminus to install dependencies.
+    By default the URL is not specified.
+
+* **HTTPD_START_SERVERS**
+
+    The [StartServers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#startservers)
+    directive sets the number of child server processes created on startup. Default is 8.
+
+* **HTTPD_MAX_REQUEST_WORKERS**
+
+    Number of simultaneous requests that will be handled by Apache httpd. The default
+    is 256, but it will be automatically lowered if memory is limited.
+
+* **PSGI_FILE**
+
+    Override PSGI application detection.
+
+    If the PSGI_FILE variable is set to an empty value, no PSGI application will
+    be detected and mod_fcgid will not be reconfigured.
+
+    If the PSGI_FILE variable is set and non-empty, it will define path to
+    a PSGI application file and mod_fcgid will be configured to execute that
+    file.
+
+    If the PSGI_FILE variable does not exist, autodetection will be used:
+    If exactly one ./*.psgi file exists, mod_fcgid will be configured to
+    execute that file.
+
+* **PSGI_URI_PATH**
+
+    This variable overrides location URI path that is handled path the PSGI
+    application. Default value is "/".
+
+
+See also
+--------
+Dockerfile and other sources are available on https://github.com/sclorg/s2i-perl-container.
+In that repository you also can find another versions of Perl environment Dockerfiles.
+Dockerfile for CentOS is called Dockerfile, Dockerfile for RHEL is called Dockerfile.rhel8.

--- a/5.26-mod_fcgid/root/opt/app-root/Plack-1.0047-Work-around-mod_fcgid-bogus-SCRIPT_NAME-PATH_INFO.patch
+++ b/5.26-mod_fcgid/root/opt/app-root/Plack-1.0047-Work-around-mod_fcgid-bogus-SCRIPT_NAME-PATH_INFO.patch
@@ -1,0 +1,49 @@
+From d65d28410b91dfb3d9d12b6b8e49a79c7da54e1c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Wed, 9 Jan 2019 12:33:59 +0100
+Subject: [PATCH] Work around mod_fcgid bogus SCRIPT_NAME/PATH_INFO
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+mod_fcgid sends wrong PATH_INFO to virtual FcgidWrapper and that
+prevents Plack from passing an application path to PSGI.
+
+This adds a side channel for passing application URI location to
+Plack's FCGI handler.
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1651746
+<https://github.com/plack/Plack/issues/308>
+<https://github.com/plack/Plack/issues/147>
+<https://github.com/plack/Plack/issues/281>
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ lib/Plack/Handler/FCGI.pm | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/lib/Plack/Handler/FCGI.pm b/lib/Plack/Handler/FCGI.pm
+index 029051c..0c491b2 100644
+--- a/lib/Plack/Handler/FCGI.pm
++++ b/lib/Plack/Handler/FCGI.pm
+@@ -124,6 +124,17 @@ sub run {
+         delete $env->{HTTP_CONTENT_TYPE};
+         delete $env->{HTTP_CONTENT_LENGTH};
+ 
++        # mod_fcgid provides wrong SCRIPT_NAME and PATH_INFO for virtual FCGI script handlers
++        # <https://github.com/plack/Plack/issues/308>
++        # <https://github.com/plack/Plack/issues/147>
++        # <https://github.com/plack/Plack/issues/281>
++        if (exists $ENV{MODFCGID_VIRTUAL_LOCATION}) {
++            if ($ENV{MODFCGID_VIRTUAL_LOCATION} eq '/') {
++                $ENV{MODFCGID_VIRTUAL_LOCATION} = '';
++            }
++            $env->{SCRIPT_NAME} = $ENV{MODFCGID_VIRTUAL_LOCATION};
++        }
++
+         # lighttpd munges multiple slashes in PATH_INFO into one. Try recovering it
+         my $uri = URI->new("http://localhost" .  $env->{REQUEST_URI});
+         $env->{PATH_INFO} = uri_unescape($uri->path);
+-- 
+2.17.2
+

--- a/5.26-mod_fcgid/root/opt/app-root/etc/httpd.conf
+++ b/5.26-mod_fcgid/root/opt/app-root/etc/httpd.conf
@@ -1,0 +1,37 @@
+LoadModule env_module modules/mod_env.so
+
+<IfModule mpm_worker_module>
+   LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_event_module>
+   LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+   LoadModule cgi_module modules/mod_cgi.so
+</IfModule>
+
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule fcgid_module modules/mod_fcgid.so
+
+FcgidIPCDir /run/mod_fcgid
+FcgidProcessTableFile /run/mod_fcgid/fcgid_shm
+
+DirectoryIndex index.pl index.cgi index.fcg index.fcgi index.fpl
+
+<Files ~ "\.(pl|cgi)$">
+    SetHandler cgi-script
+    Options +ExecCGI +SymLinksIfOwnerMatch
+</Files>
+
+<Files ~ "\.(fcg|fcgi|fpl)$">
+    SetHandler fcgid-script
+    Options +ExecCGI +SymLinksIfOwnerMatch
+</Files>
+
+<Directory "/opt/app-root/src">
+  Require all granted
+</Directory>
+
+IncludeOptional /opt/app-root/etc/httpd.d/*.conf

--- a/5.26-mod_fcgid/root/opt/app-root/etc/httpd.d/50-mpm.conf.template
+++ b/5.26-mod_fcgid/root/opt/app-root/etc/httpd.d/50-mpm.conf.template
@@ -1,0 +1,13 @@
+# This value should mirror what is set in MinSpareServers.
+StartServers            ${HTTPD_START_SERVERS}
+<IfModule mpm_prefork_module>
+    MinSpareServers         ${HTTPD_START_SERVERS}
+    MaxSpareServers         ${HTTPD_MAX_SPARE_SERVERS}
+</IfModule>
+# The MaxRequestWorkers directive sets the limit on the number of
+# simultaneous requests that will be served.
+# The default value, when no cgroup limits are set is 256.
+MaxRequestWorkers       ${HTTPD_MAX_REQUEST_WORKERS}
+ServerLimit             ${HTTPD_MAX_REQUEST_WORKERS}
+MaxConnectionsPerChild  4000
+MaxKeepAliveRequests    100

--- a/5.26-mod_fcgid/root/opt/app-root/etc/httpdconf.sed
+++ b/5.26-mod_fcgid/root/opt/app-root/etc/httpdconf.sed
@@ -1,0 +1,7 @@
+s/^Listen 80/Listen 0.0.0.0:8080/
+s/^User apache/User default/
+s/^Group apache/Group root/
+s%^DocumentRoot "/var/www/html"%DocumentRoot "/opt/app-root/src"%
+s%^<Directory "/var/www/html"%<Directory "/opt/app-root/src"%
+s%^ErrorLog "logs/error_log"%ErrorLog "|/usr/bin/cat"%
+s%CustomLog "logs/access_log"%CustomLog "|/usr/bin/cat"%

--- a/5.26-mod_fcgid/root/opt/app-root/psgiwrapper
+++ b/5.26-mod_fcgid/root/opt/app-root/psgiwrapper
@@ -1,0 +1,4 @@
+#!/usr/bin/perl
+# mod_fcgid chdirs to wrapper's path, restore CWD to $HOME
+chdir $ENV{'HOME'} if exists $ENV{'HOME'};
+exec(@ARGV) or die "Could not execute PSGI script: @ARGV: $!";

--- a/5.26-mod_fcgid/s2i/bin/assemble
+++ b/5.26-mod_fcgid/s2i/bin/assemble
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -e
+
+shopt -s dotglob
+echo "---> Installing application source ..."
+mv /tmp/src/* ./
+
+if [ -d ./cfg ]; then
+  echo "---> Copying configuration files..."
+  if [ "$(ls -A ./cfg/*.conf)" ]; then
+    cp -v ./cfg/*.conf /opt/app-root/etc/httpd.d/
+  fi
+fi
+
+# Allow for http proxy to be specified in uppercase
+if [[ -n "${HTTP_PROXY:-}" && -z "${http_proxy:-}" ]]; then
+  export http_proxy=$HTTP_PROXY
+fi
+
+export CPAN_MIRROR=${CPAN_MIRROR:-""}
+
+MIRROR_ARGS=""
+
+if [ -n "$CPAN_MIRROR" ]; then
+  MIRROR_ARGS="--mirror $CPAN_MIRROR"
+fi
+
+# Don't test installed Perl modules by default
+if [ "${ENABLE_CPAN_TEST}" = true ]; then
+  export ENABLE_CPAN_TEST=""
+else
+  export ENABLE_CPAN_TEST="--notest"
+fi
+
+# Configure mod_fcgid for PSGI.
+# If PSGI_FILE variable is set but empty, skip it.
+# If PSGI_FILE is set and non-empty, use it.
+# If PSGI_FILE does not exist, check if exactly one ./*.psgi file exists and
+# use that file.
+# If PSGI_URI_PATH variable has a value, use it as a location. Default is "/".
+PSGI_URI_PATH="${PSGI_URI_PATH:=/}"
+if [ ! -v PSGI_FILE ]; then
+    PSGI_FILE=$(find -maxdepth 1 -name '*.psgi' -type f)
+fi
+PSGI_FILE_NUMBER=$(printf '%s' "$PSGI_FILE" | wc -l)
+if [ -n "$PSGI_FILE" -a "$PSGI_FILE_NUMBER" -eq 0 ]; then
+    CONFIGURE_PSGI=1;
+fi
+if [ -n "$CONFIGURE_PSGI" ]; then
+    echo "---> PSGI application found in $PSGI_FILE"
+    cat >> cpanfile <<"EOF"
+requires 'Plack::Handler::FCGI';
+requires 'FCGI::ProcManager';
+EOF
+    # XXX: Escape PSGI_FILE value against httpd control characters
+    PSGI_FILE=$(printf '%s' "$PSGI_FILE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+    cat > /opt/app-root/etc/httpd.d/40-psgi.conf <<EOF
+FcgidInitialEnv MODFCGID_VIRTUAL_LOCATION ${PSGI_URI_PATH}
+<Location ${PSGI_URI_PATH}>
+    SetHandler fcgid-script
+    Options +ExecCGI
+    FcgidWrapper "/opt/app-root/psgiwrapper /usr/bin/env plackup -s FCGI $PSGI_FILE" virtual
+</Location>
+EOF
+elif [ "$PSGI_FILE_NUMBER" -gt 0 ]; then
+    echo "---> Multiple PSGI applications found:"
+    printf '%s' "$PSGI_FILE"
+    echo "---> Skipping PSGI autoconfiguration!"
+fi
+
+# Installing dependencies with cpanfile
+if [ -f "cpanfile" ]; then
+  echo "---> Installing modules from cpanfile ..."
+  set +e
+  cpanm --no-interactive $MIRROR_ARGS $ENABLE_CPAN_TEST -l extlib --installdeps .
+  if [ $? != 0 ]; then
+    echo "---> Module installation failed, build.log content is:"
+    cat .cpanm/build.log
+    echo "---> Module installation failed!"
+    exit 1;
+  fi
+  set -e
+else
+  echo "---> No cpanfile found, nothing to install"
+fi
+
+# Make Plack compatible with broken mod_fcgi (bug #1651746)
+if [ -n "$CONFIGURE_PSGI" ]; then
+    echo "---> Patching Plack::Handler::FCGI to work with mod_fcgi ..."
+    pushd ./extlib/lib/perl5
+    patch --read-only=ignore -p2 < /opt/app-root/Plack-1.0047-Work-around-mod_fcgid-bogus-SCRIPT_NAME-PATH_INFO.patch
+    popd
+fi
+
+# Fix source directory permissions
+fix-permissions ./

--- a/5.26-mod_fcgid/s2i/bin/run
+++ b/5.26-mod_fcgid/s2i/bin/run
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+# cpanm can install scripts. They should be available too.
+export PATH=${PATH}:/opt/app-root/src/extlib/bin
+# And we have to set Perl include path too because cpanm can install modules.
+export PERL5LIB=/opt/app-root/src/extlib/lib/perl5
+
+# Warning: Please note that this will pass all environment variables available
+# within the container to mod_cgid by means of PassEnv and to mod_fcgid by
+# means of FcgidInitialEnv in the env.conf file.
+if [ ! -f /opt/app-root/etc/httpd.d/env.conf ]; then
+  env | awk -F'=' '{print "PassEnv "$1"\nFcgidInitialEnv "$1" \""$2"\""}' \
+      > /opt/app-root/etc/httpd.d/env.conf
+fi
+
+export_vars=$(cgroup-limits) ; export $export_vars
+
+# Validate server limit option
+if [[ ! "${HTTPD_MAX_REQUEST_WORKERS:-1}" =~ ^[1-9][0-9]*$ || "${HTTPD_MAX_REQUEST_WORKERS:-1}" -gt 20000 ]]; then
+  echo "HTTPD_MAX_REQUEST_WORKERS needs be an integer between 1 and 20000"
+  exit 1
+fi
+
+# If there is no server limit specified, try to guess the best value
+if [ -z "${HTTPD_MAX_REQUEST_WORKERS:-}" ]; then
+  MAX_SERVER_LIMIT=$(((MEMORY_LIMIT_IN_BYTES/1024/1024 - 30) / 7))
+  MAX_SERVER_LIMIT=$((MAX_SERVER_LIMIT > 0 ? MAX_SERVER_LIMIT : 1))
+  export HTTPD_MAX_REQUEST_WORKERS=$((MAX_SERVER_LIMIT > 256 ? 256 : MAX_SERVER_LIMIT))
+fi
+
+export HTTPD_START_SERVERS=${HTTPD_START_SERVERS:-8}
+export HTTPD_MAX_SPARE_SERVERS=$((HTTPD_START_SERVERS+10))
+
+envsubst < /opt/app-root/etc/httpd.d/50-mpm.conf.template > /opt/app-root/etc/httpd.d/50-mpm.conf
+
+exec httpd -C 'Include /opt/app-root/etc/httpd.conf' -D FOREGROUND

--- a/5.26-mod_fcgid/s2i/bin/usage
+++ b/5.26-mod_fcgid/s2i/bin/usage
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=centos
+SUFFIX='-centos8'
+if [[ $DISTRO =~ rhel* ]]; then
+    NAMESPACE=rhel8
+    SUFFIX=''
+fi
+
+cat <<EOF
+This is a S2I ${IMAGE_DESCRIPTION} ${DISTRO} base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+s2i build https://github.com/sclorg/s2i-perl-container.git --context-dir=5.26/test/sample-test-app/ ${NAMESPACE}/perl-526${SUFFIX} perl-sample-app
+
+You can then run the resulting image via:
+docker run -p 8080:8080 perl-sample-app
+EOF

--- a/5.26-mod_fcgid/test/binpath/cpanfile
+++ b/5.26-mod_fcgid/test/binpath/cpanfile
@@ -1,0 +1,1 @@
+requires 'Net::IP';

--- a/5.26-mod_fcgid/test/binpath/index.pl
+++ b/5.26-mod_fcgid/test/binpath/index.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/perl
+print "Content-type: text/plain\n\n";
+my $output = `ipcount 2>&1`;
+if (!defined $output) {
+    die "No output from `ipcount' command";
+}
+print $output;

--- a/5.26-mod_fcgid/test/fcgi/another.fcgi
+++ b/5.26-mod_fcgid/test/fcgi/another.fcgi
@@ -1,0 +1,7 @@
+#!/usr/bin/perl
+use FCGI;
+my $request = FCGI::Request();
+while ($request->Accept() >= 0) {
+        print "Content-Type: text/plain\r\n\r\n";
+        print "Another FCGI script.\n";
+}

--- a/5.26-mod_fcgid/test/fcgi/index.fcgi
+++ b/5.26-mod_fcgid/test/fcgi/index.fcgi
@@ -1,0 +1,7 @@
+#!/usr/bin/perl
+use FCGI;
+my $request = FCGI::Request();
+while ($request->Accept() >= 0) {
+        print "Content-Type: text/plain\r\n\r\n";
+        print "Index FCGI script.\n";
+}

--- a/5.26-mod_fcgid/test/psgi-variables/application1.psgi
+++ b/5.26-mod_fcgid/test/psgi-variables/application1.psgi
@@ -1,0 +1,1 @@
+die "This should not be picked up.";

--- a/5.26-mod_fcgid/test/psgi-variables/application2.psgi
+++ b/5.26-mod_fcgid/test/psgi-variables/application2.psgi
@@ -1,0 +1,3 @@
+#!/usr/bin/env plackup
+use Web::Paste::Simple;
+Web::Paste::Simple->new->app;

--- a/5.26-mod_fcgid/test/psgi-variables/cpanfile
+++ b/5.26-mod_fcgid/test/psgi-variables/cpanfile
@@ -1,0 +1,1 @@
+requires 'Web::Paste::Simple';

--- a/5.26-mod_fcgid/test/psgi/application.psgi
+++ b/5.26-mod_fcgid/test/psgi/application.psgi
@@ -1,0 +1,3 @@
+#!/usr/bin/env plackup
+use Web::Paste::Simple;
+Web::Paste::Simple->new->app;

--- a/5.26-mod_fcgid/test/psgi/cpanfile
+++ b/5.26-mod_fcgid/test/psgi/cpanfile
@@ -1,0 +1,1 @@
+requires 'Web::Paste::Simple';

--- a/5.26-mod_fcgid/test/run
+++ b/5.26-mod_fcgid/test/run
@@ -1,0 +1,322 @@
+#!/bin/bash
+#
+# The 'run' performs a simple test that verifies that S2I image.
+# The main focus here is to exercise the S2I scripts.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+IMAGE_NAME=${IMAGE_NAME-centos/perl-526-centos-candidate}
+
+# TODO: Make command compatible for Mac users
+test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
+image_dir=$(readlink -zf ${test_dir}/..)
+
+source "${test_dir}/test-lib.sh"
+
+# TODO: This should be part of the image metadata
+test_port=8080
+
+info() {
+  echo -e "\n\e[1m[INFO] $@...\e[0m\n"
+}
+
+image_exists() {
+  docker inspect $1 &>/dev/null
+}
+
+container_exists() {
+  image_exists $(cat $cid_file)
+}
+
+container_ip() {
+  docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file)
+}
+
+run_s2i_build() {
+  ct_s2i_build_as_df file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp "$@"
+}
+
+prepare() {
+  if ! image_exists ${IMAGE_NAME}; then
+    echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
+    exit 1
+  fi
+  # TODO: S2I build require the application is a valid 'GIT' repository, we
+  # should remove this restriction in the future when a file:// is used.
+  info "Build the test application image"
+  pushd ${test_dir}/${test_name} >/dev/null
+  git init
+  git config user.email "build@localhost" && git config user.name "builder"
+  git add -A && git commit -m "Sample commit"
+  popd >/dev/null
+}
+
+run_test_application() {
+  docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-testapp
+}
+
+cleanup_test_app() {
+  info "Cleaning up the test application"
+  if [ -f $cid_file ]; then
+    if container_exists; then
+      docker stop $(cat $cid_file)
+      docker rm $(cat $cid_file)
+    fi
+    rm $cid_file
+  fi
+}
+
+cleanup() {
+  info "Cleaning up the test application image"
+  if image_exists ${IMAGE_NAME}-testapp; then
+    docker rmi -f ${IMAGE_NAME}-testapp
+  fi
+  rm -rf ${test_dir}/${test_name}/.git
+}
+
+check_result() {
+  local result="$1"
+  if [[ "$result" != "0" ]]; then
+    info "TEST FAILED (${result})"
+    cleanup
+    exit $result
+  fi
+}
+
+wait_for_cid() {
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  info "Waiting for application container to start"
+  while [ $attempt -le $max_attempts ]; do
+    [ -f $cid_file ] && [ -s $cid_file ] && break
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+}
+
+test_s2i_usage() {
+  info "Testing 's2i usage'"
+  ct_s2i_usage ${IMAGE_NAME} ${s2i_args} &>/dev/null
+}
+
+test_docker_run_usage() {
+  info "Testing 'docker run' usage"
+  docker run ${IMAGE_NAME} &>/dev/null
+}
+
+test_scl_usage() {
+  local run_cmd="$1"
+  local expected="$2"
+
+  info "Testing the image SCL enable"
+  out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}")
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(cat ${cid_file}) /bin/sh -ic "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+}
+
+# Perform GET request to the application container.
+# First argument is request URI path.
+# Second argument is expected HTTP response code.
+# Third argument is PCRE regular expression that must match the response body.
+test_response() {
+  local uri_path="$1"
+  local expected_code="$2"
+  local body_regexp="$3"
+
+  local url="http://$(container_ip):${test_port}${uri_path}"
+  info "Testing the HTTP response for <${url}>"
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  while [ $attempt -le $max_attempts ]; do
+    response=$(curl -s -w '%{http_code}' "${url}")
+    status=$?
+    if [ $status -eq 0 ]; then
+      response_code=$(printf '%s' "$response" | tail -c 3)
+      response_body=$(printf '%s' "$response" | head -c -3)
+      if [ "$response_code" -eq "$expected_code" ]; then
+        result=0
+      fi
+      printf '%s' "$response_body" | grep -qP -e "$body_regexp" || result=1;
+      break
+    fi
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+  return $result
+}
+
+# Match PCRE regular expression against container standard output.
+# First argument is the PCRE regular expression.
+# It expects standard output in ${tmp_dir}/out file.
+test_stdout() {
+  local regexp="$1"
+  local output="${tmp_dir}/out"
+  info "Testing the container standard output for /${regexp}/"
+  grep -qP -e "$regexp" "$output";
+}
+
+# Match PCRE regular expression against container standard error output.
+# First argument is the PCRE regular expression.
+# It expects error output in ${tmp_dir}/err file.
+test_stderr() {
+  local regexp="$1"
+  local output="${tmp_dir}/err"
+  info "Testing the container error output for /${regexp}/"
+  grep -qP -e "$regexp" "$output";
+}
+
+test_connection() {
+    test_response '/' 200 ''
+}
+
+test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_scl_usage "perl --version" "v5.26."
+  check_result $?
+
+  test_connection
+  check_result $?
+  cleanup_test_app
+}
+
+# Build application, run it, perform test function, clean up.
+# First argument is directory name.
+# Second argument is function that expects running application. The function
+# must return (or terminate with) non-zero value to report an failure,
+# 0 otherwise.
+# Other arguments are additional s2i options, like --env=FOO=bar.
+# The test function have available container ID in $cid_file, container output
+# in ${tmp_dir}/out, container stderr in ${tmp_dir}/err.
+do_test() {
+    test_name="$1"
+    test_function="$2"
+    shift 2
+
+    info "Starting tests for ${test_name}."
+
+    tmp_dir=$(mktemp -d)
+    check_result $?
+    cid_file="${tmp_dir}/cid"
+    s2i_args="--pull-policy=never"
+
+    # Build and run the test application
+    prepare
+    run_s2i_build $s2i_args "$@"
+    check_result $?
+    run_test_application >"${tmp_dir}/out" 2>"${tmp_dir}/err" &
+    wait_for_cid
+
+    # Perform user-supplied test function
+    $test_function;
+    check_result $?
+
+    # Terminate the test application and clean up
+    cleanup_test_app
+    cleanup
+    rm -rf "$tmp_dir"
+    info "All tests for the ${test_name} finished successfully."
+}
+
+
+# List of tests to execute:
+
+# This is original test that does more things like s2i API checks. Other tests
+# executed by do_test() will not repeat these checks.
+test_1() {
+    test_name='sample-test-app'
+    info "Starting tests for ${test_name}"
+
+    cid_file=$(mktemp -u --suffix=.cid)
+
+    # Since we built the candidate image locally, we don't want S2I attempt to pull
+    # it from Docker hub
+    s2i_args="--pull-policy=never"
+
+    prepare
+    run_s2i_build $s2i_args
+    check_result $?
+
+    # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
+    test_s2i_usage
+    check_result $?
+
+    # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
+    test_docker_run_usage
+    check_result $?
+
+    # Test application with default UID
+    test_application
+
+    # Test application with random UID
+    CONTAINER_ARGS="-u 12345" test_application
+
+    info "All tests for the ${test_name} finished successfully."
+    cleanup
+}
+test_1
+
+# Check scripts installed from CPAN are available to the application.
+test_2_function() {
+    test_response '/' 200 'Usage'
+}
+do_test 'binpath' 'test_2_function'
+
+# Check a single PSGI application is recognized a mod_fcgid is autoconfigured.
+test_3_function() {
+    test_response '/' 200 '<title>Web::Paste::Simple'
+}
+do_test 'psgi' 'test_3_function'
+
+# Check variables can select a PSGI application and set URI path.
+test_4_function() {
+    test_response '/path' 200 '<title>Web::Paste::Simple' && \
+    test_response '/cpanfile' 200 'requires'
+}
+do_test 'psgi-variables' 'test_4_function' \
+    '--env=PSGI_FILE=./application2.psgi' '--env=PSGI_URI_PATH=/path'
+
+# Check httpd access_log flows to stdout, error_log to stdout.
+# TODO: send error_log to stderr after dropping support for broken
+# docker < 1.9.
+test_5_function() {
+    test_response '/' 200 'Text in HTTP body' && \
+    test_stdout '"GET /[^"]*" 200 ' && \
+    test_stdout 'Warning on stderr'
+}
+do_test 'warningonstderr' 'test_5_function'
+
+# Check that httpd starts *.fcgi scripts via FCGI interface.
+# Checks it also recognizes index.fcgi as an index document.
+test_6_function() {
+    test_response '/another.fcgi' 200 'Another FCGI script.'
+    test_response '/' 200 'Index FCGI script.'
+}
+do_test 'fcgi' 'test_6_function'
+
+echo "Testing npm availibility"
+ct_npm_works
+check_result $?
+
+info "All tests finished successfully."

--- a/5.26-mod_fcgid/test/run-openshift
+++ b/5.26-mod_fcgid/test/run-openshift
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Test the Perl image in OpenShift.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+
+source ${THISDIR}/test-lib.sh
+source ${THISDIR}/test-lib-openshift.sh
+
+set -exo nounset
+
+test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
+test -n "${VERSION-}" || false 'make sure $VERSION is defined'
+
+ct_os_cluster_up
+
+# TODO: We should ideally use a local directory instead of ${VERSION}/test/sample-test-app,
+# so we can test changes in that example app that are done as part of the PR
+ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/s2i-perl-container.git" ${VERSION}/test/sample-test-app "Everything is OK"
+
+ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/dancer-ex.git" . 'Welcome to your Dancer application on OpenShift'
+
+# TODO: this was not working because the referenced example dir was added as part of this commit
+ct_os_test_template_app ${IMAGE_NAME} \
+                        ${THISDIR}/sample-test-app.json \
+                        perl \
+                        "Everything is OK" \
+                        8080 http 200 "-p SOURCE_REPOSITORY_REF=staging -p VERSION=${VERSION} -p NAME=perl-testing"
+

--- a/5.26-mod_fcgid/test/sample-test-app
+++ b/5.26-mod_fcgid/test/sample-test-app
@@ -1,0 +1,1 @@
+../../examples/sample-test-app/

--- a/5.26-mod_fcgid/test/sample-test-app.json
+++ b/5.26-mod_fcgid/test/sample-test-app.json
@@ -1,0 +1,1 @@
+../../examples/templates/sample-test-app.json

--- a/5.26-mod_fcgid/test/test-lib-openshift.sh
+++ b/5.26-mod_fcgid/test/test-lib-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-openshift.sh

--- a/5.26-mod_fcgid/test/test-lib.sh
+++ b/5.26-mod_fcgid/test/test-lib.sh
@@ -1,0 +1,1 @@
+../../common/test-lib.sh

--- a/5.26-mod_fcgid/test/warningonstderr/index.pl
+++ b/5.26-mod_fcgid/test/warningonstderr/index.pl
@@ -1,0 +1,4 @@
+#!/usr/bin/perl
+print "Content-type: text/plain\n\n";
+warn "Warning on stderr\n";
+print "Text in HTTP body\n";

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in common/build.sh.
 BASE_IMAGE_NAME = perl
-VERSIONS = 5.24 5.26
+VERSIONS = 5.24 5.26 5.26-mod_fcgid
 OPENSHIFT_NAMESPACES = 5.16
 
 # HACK:  Ensure that 'git pull' for old clones doesn't cause confusion.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Perl versions currently provided:
 
 RHEL versions currently supported:
 * RHEL7
+* RHEL8
 
 CentOS versions currently supported:
 * CentOS7


### PR DESCRIPTION
5.26-mod_fcgid differs from 5.26. 5.26 was built on Perl 5.26 and
mod_perl from RHSCL. 5.26-mod_fcgid is built on Perl 5.26 and
mod_fcgid from modules.

RHEL7 does not contain perl-FCGI. 5.26-mod_fcgid removed SCL
infrastructure. Thus 5.26-mod_fcgi is not supported on RHEL7.

F29 does not contain non-modular 5.26 and perl-FCGI for 5.26. F28
contains Perl 5.26, but mod_fcgid is broken there. Thus 5.26-mod_fcgi
is not supported on Fedora.