### PR TITLE
5.24: Install all core modules

### DIFF
--- a/5.24/Dockerfile
+++ b/5.24/Dockerfile
@@ -34,7 +34,7 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> centos/${NAME}-${PERL_SHORT_VER}-centos7:latest <APP-NAME>"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="rh-perl524 rh-perl524-perl-devel rh-perl524-mod_perl rh-perl524-perl-CPAN rh-perl524-perl-App-cpanminus" && \
+    INSTALL_PKGS="rh-perl524 rh-perl524-perl-core rh-perl524-perl-devel rh-perl524-mod_perl rh-perl524-perl-CPAN rh-perl524-perl-App-cpanminus" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/5.24/Dockerfile.rhel7
+++ b/5.24/Dockerfile.rhel7
@@ -35,7 +35,7 @@ LABEL summary="$SUMMARY" \
 
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-    INSTALL_PKGS="rh-perl524 rh-perl524-perl-devel rh-perl524-mod_perl rh-perl524-perl-CPAN rh-perl524-perl-App-cpanminus" && \
+    INSTALL_PKGS="rh-perl524 rh-perl524-perl-core rh-perl524-perl-devel rh-perl524-mod_perl rh-perl524-perl-CPAN rh-perl524-perl-App-cpanminus" && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all


### PR DESCRIPTION
Some core modules do not live on CPAN and cannot be installed in an
assemble phase. E.g. Devel::Peek.

This patch preinstalls rh-perl524-perl-core RPM package that ensures
that all core modules are available in the assemble phase.

This is not an issue for 5.26 where the same guarantee is implemented
by explicitly installed rh-perl526-perl RPM package.