### PR TITLE
Fix permissions for all files given in s2i

### DIFF
--- a/5.24/s2i/bin/assemble
+++ b/5.24/s2i/bin/assemble
@@ -6,10 +6,13 @@ shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
+# Fix source directory permissions
+fix-permissions ./
+
 if [ -d ./cfg ]; then
   echo "---> Copying configuration files..."
   if [ "$(ls -A ./cfg/*.conf)" ]; then
-    cp -v ./cfg/*.conf /opt/app-root/etc/httpd.d/
+    cp -av ./cfg/*.conf /opt/app-root/etc/httpd.d/
   fi
 fi
 

--- a/5.26-mod_fcgid/s2i/bin/assemble
+++ b/5.26-mod_fcgid/s2i/bin/assemble
@@ -6,10 +6,13 @@ shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
+# Fix source directory permissions
+fix-permissions ./
+
 if [ -d ./cfg ]; then
   echo "---> Copying configuration files..."
   if [ "$(ls -A ./cfg/*.conf)" ]; then
-    cp -v ./cfg/*.conf /opt/app-root/etc/httpd.d/
+    cp -av ./cfg/*.conf /opt/app-root/etc/httpd.d/
   fi
 fi
 

--- a/5.26/s2i/bin/assemble
+++ b/5.26/s2i/bin/assemble
@@ -6,10 +6,13 @@ shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
+# Fix source directory permissions
+fix-permissions ./
+
 if [ -d ./cfg ]; then
   echo "---> Copying configuration files..."
   if [ "$(ls -A ./cfg/*.conf)" ]; then
-    cp -v ./cfg/*.conf /opt/app-root/etc/httpd.d/
+    cp -av ./cfg/*.conf /opt/app-root/etc/httpd.d/
   fi
 fi
 


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Adds fix-permissions right after `mv` command. `cp` command also has parameter `-a`.


Reference issue:
https://github.com/sclorg/container-common-scripts/issues/119