### PR TITLE
Add support for internal Nexus registry

### DIFF
--- a/5.24/s2i/bin/assemble
+++ b/5.24/s2i/bin/assemble
@@ -29,6 +29,11 @@ if [ -n "$CPAN_MIRROR" ]; then
   MIRROR_ARGS="--mirror $CPAN_MIRROR"
 fi
 
+# Change the npm registry mirror if provided
+if [ -n "$NPM_MIRROR" ]; then
+	npm config set registry $NPM_MIRROR
+fi
+
 # Don't test installed Perl modules by default
 if [ "${ENABLE_CPAN_TEST}" = true ]; then
   export ENABLE_CPAN_TEST=""

--- a/5.24/test/run
+++ b/5.24/test/run
@@ -34,7 +34,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  ct_s2i_build_as_df file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp "$@"
+  ct_s2i_build_as_df file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp $(ct_build_s2i_npm_variables) "$@"
 }
 
 prepare() {

--- a/5.26/s2i/bin/assemble
+++ b/5.26/s2i/bin/assemble
@@ -29,6 +29,11 @@ if [ -n "$CPAN_MIRROR" ]; then
   MIRROR_ARGS="--mirror $CPAN_MIRROR"
 fi
 
+# Change the npm registry mirror if provided
+if [ -n "$NPM_MIRROR" ]; then
+	npm config set registry $NPM_MIRROR
+fi
+
 # Don't test installed Perl modules by default
 if [ "${ENABLE_CPAN_TEST}" = true ]; then
   export ENABLE_CPAN_TEST=""

--- a/5.26/test/run
+++ b/5.26/test/run
@@ -34,7 +34,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  ct_s2i_build_as_df file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp "$@"
+  ct_s2i_build_as_df file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp $(ct_build_s2i_npm_variables) "$@"
 }
 
 prepare() {


### PR DESCRIPTION
Add parameter `ct_build_s2i_npm_variables`
into `run_s2i_build` function.
It checks if internal NPM_REGISTRY is set and
CA file is present. Else use public NPM registry.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>