### PR TITLE
Fix npm_test and update container-common-scripts

### DIFF
--- a/5.26-mod_fcgid/s2i/bin/assemble
+++ b/5.26-mod_fcgid/s2i/bin/assemble
@@ -29,6 +29,12 @@ if [ -n "$CPAN_MIRROR" ]; then
   MIRROR_ARGS="--mirror $CPAN_MIRROR"
 fi
 
+# Change the npm registry mirror if provided
+if [ -n "$NPM_MIRROR" ]; then
+  npm config set registry $NPM_MIRROR
+fi
+
+
 # Don't test installed Perl modules by default
 if [ "${ENABLE_CPAN_TEST}" = true ]; then
   export ENABLE_CPAN_TEST=""

--- a/5.26-mod_fcgid/test/run
+++ b/5.26-mod_fcgid/test/run
@@ -34,7 +34,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  ct_s2i_build_as_df file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp "$@"
+  ct_s2i_build_as_df file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp $(ct_build_s2i_npm_variables) "$@"
 }
 
 prepare() {

--- a/5.26-mod_fcgid/test/run
+++ b/5.26-mod_fcgid/test/run
@@ -315,8 +315,22 @@ test_6_function() {
 }
 do_test 'fcgi' 'test_6_function'
 
-echo "Testing npm availibility"
-ct_npm_works
-check_result $?
+test_npm() {
+    test_name='sample-test-app'
+    info "Testing npm availibility"
+    # Since we built the candidate image locally, we don't want S2I attempt to pull
+    # it from Docker hub
+    s2i_args="--pull-policy=never"
+
+    prepare
+    run_s2i_build $s2i_args
+    check_result $?
+
+    ct_npm_works
+    check_result $?
+
+    cleanup
+}
+test_npm
 
 info "All tests finished successfully."

--- a/5.26/test/run
+++ b/5.26/test/run
@@ -308,6 +308,7 @@ test_5_function() {
 do_test 'warningonstderr' 'test_5_function'
 
 test_npm() {
+    test_name='sample-test-app'
     info "Testing npm availibility"
     # Since we built the candidate image locally, we don't want S2I attempt to pull
     # it from Docker hub

--- a/5.26/test/run
+++ b/5.26/test/run
@@ -307,8 +307,21 @@ test_5_function() {
 }
 do_test 'warningonstderr' 'test_5_function'
 
-echo "Testing npm availibility"
-ct_npm_works
-check_result $?
+test_npm() {
+    info "Testing npm availibility"
+    # Since we built the candidate image locally, we don't want S2I attempt to pull
+    # it from Docker hub
+    s2i_args="--pull-policy=never"
+
+    prepare
+    run_s2i_build $s2i_args
+    check_result $?
+
+    ct_npm_works
+    check_result $?
+
+    cleanup
+}
+test_npm
 
 info "All tests finished successfully."


### PR DESCRIPTION
Fix npm_test and update container-common-scripts.

Update container-common-scripts to the latest.

This patch builds an image before testing
npm functionality. It is a prerequisite for the npm test
to have a built image.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>