### PR TITLE
The latest version at the end of VERSIONS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in common/build.sh.
 BASE_IMAGE_NAME = perl
-VERSIONS = 5.30 5.26 5.26-mod_fcgid
+VERSIONS = 5.26-mod_fcgid 5.26 5.30
 OPENSHIFT_NAMESPACES = 5.16
 
 # HACK:  Ensure that 'git pull' for old clones doesn't cause confusion.


### PR DESCRIPTION
In order to test the latest versions in
OpenShift environment, we need the latest
version at the end of variable VERSIONS.
This is done in all sclorg organization.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>