### PR TITLE
imagestreams/perl-centos7: remove 5.30

### DIFF
--- a/imagestreams/perl-centos7.json
+++ b/imagestreams/perl-centos7.json
@@ -22,27 +22,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "5.30"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "5.30",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.30",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.30 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
-          "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "supports":"perl:5.30,perl",
-          "version": "5.30",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "docker.io/centos/perl-530-centos7:latest"
+          "name": "5.26"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Perl 5.30 was never really pushed to DockerHub, so "latest" should refer
to 5.26 instead