### PR TITLE
Fix "own setup" example for mod_fcgid images

### DIFF
--- a/5.26-mod_fcgid/README.md
+++ b/5.26-mod_fcgid/README.md
@@ -101,15 +101,30 @@ FROM ubi8/perl-526
 # Add application sources
 ADD app-src .
 
+# Set the paths to local Perl modules
+ENV PATH=${PATH}:/opt/app-root/src/extlib/bin
+ENV PERL5LIB=/opt/app-root/src/extlib/lib/perl5
+
 # Install the dependencies
 RUN  cpanm --notest -l extlib Module::CoreList && \
      cpanm --notest -l extlib --installdeps .
 
-CMD sed -i '1i<Location/>' /opt/app-root/etc/httpd.d/40-psgi.conf
-CMD sed -i '2iSetHandler perl-script' /opt/app-root/etc/httpd.d/40-psgi.conf
-CMD sed -i '3iPerlResponseHandler Plack::Handler::Apache2' /opt/app-root/etc/httpd.d/40-psgi.conf
-CMD sed -i '4iPerlSetVar psgi_app app.psgi' /opt/app-root/etc/httpd.d/40-psgi.conf
-CMD sed -i '5i</Location>' /opt/app-root/etc/httpd.d/40-psgi.conf
+# Install Plack as an FCGI server
+RUN cpanm --notest -l extlib Plack::Handler::FCGI FCGI::ProcManager
+RUN patch --read-only=ignore -d ./extlib/lib/perl5 -p2 < /opt/app-root/Plack-1.0047-Work-around-mod_fcgid-bogus-SCRIPT_NAME-PATH_INFO.patch
+RUN printf '\
+FcgidInitialEnv MODFCGID_VIRTUAL_LOCATION /\n\
+PassEnv HOME\n\
+FcgidInitialEnv "HOME" "%s"\n\
+PassEnv PATH\n\
+FcgidInitialEnv "PATH" "%s"\n\
+PassEnv PERL5LIB\n\
+FcgidInitialEnv "PERL5LIB" "%s"\n\
+<Location />\n\
+SetHandler fcgid-script\n\
+Options +ExecCGI\n\
+FcgidWrapper "/opt/app-root/psgiwrapper /usr/bin/env plackup -s FCGI ./app.psgi" virtual\n\
+</Location>\n' "$HOME" "$PATH" "$PERL5LIB"> /opt/app-root/etc/httpd.d/40-psgi.conf
 
 # Run scripts uses standard ways to run the application
 CMD exec httpd -C 'Include /opt/app-root/etc/httpd.conf' -D FOREGROUND


### PR DESCRIPTION
The examples introduced in commit
ad12949496e45c1a6f8fb9a48e0279ddf75c9299 presume mod_perl, but they do
not work with mod_fcgid.

This patch reworks the example to properly configure FCGI server from
a PSGI application where needed, i.e. in 5.26-mod_fcgid.