### PR TITLE
Use quay io instead docker

### DIFF
--- a/5.26/Dockerfile
+++ b/5.26/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7
+FROM quay.io/centos7/s2i-base-centos7
 
 # This image provides a Perl 5.26 environment you can use to run your Perl applications.
 
@@ -26,12 +26,12 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,${NAME},${NAME}${PERL_SHORT_VER}" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
-      name="centos/${NAME}-${PERL_SHORT_VER}-centos7" \
+      name="centos7/${NAME}-${PERL_SHORT_VER}-centos7" \
       com.redhat.component="rh-${NAME}${PERL_SHORT_VER}-container" \
       version="$PERL_VERSION" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \
-      usage="s2i build <SOURCE-REPOSITORY> centos/${NAME}-${PERL_SHORT_VER}-centos7:latest <APP-NAME>"
+      usage="s2i build <SOURCE-REPOSITORY> quay.io/centos7/${NAME}-${PERL_SHORT_VER}-centos7:latest <APP-NAME>"
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="rh-perl526 rh-perl526-perl rh-perl526-perl-devel rh-perl526-mod_perl rh-perl526-perl-Apache-Reload rh-perl526-perl-CPAN rh-perl526-perl-App-cpanminus" && \

--- a/5.26/README.md
+++ b/5.26/README.md
@@ -1,10 +1,10 @@
 Perl 5.26 container image
-==========================
+=========================
 
 This container image includes Perl 5.26 as an [S2I](https://github.com/openshift/source-to-image) base image for your Perl 5.26 applications.
 Users can choose between RHEL, CentOS and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 

--- a/5.30/Dockerfile
+++ b/5.30/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7
+FROM quay.io/centos7/s2i-base-centos7
 
 # This image provides a Perl 5.30 environment you can use to run your Perl applications.
 
@@ -26,12 +26,12 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,${NAME},${NAME}${PERL_SHORT_VER}" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
-      name="centos/${NAME}-${PERL_SHORT_VER}-centos7" \
+      name="centos7/${NAME}-${PERL_SHORT_VER}-centos7" \
       com.redhat.component="rh-${NAME}${PERL_SHORT_VER}-container" \
       version="$PERL_VERSION" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \
-      usage="s2i build <SOURCE-REPOSITORY> centos/${NAME}-${PERL_SHORT_VER}-centos7:latest <APP-NAME>"
+      usage="s2i build <SOURCE-REPOSITORY> quay.io/centos7/${NAME}-${PERL_SHORT_VER}-centos7:latest <APP-NAME>"
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="rh-perl530 rh-perl530-perl rh-perl530-perl-devel rh-perl530-mod_perl rh-perl530-perl-Apache-Reload rh-perl530-perl-CPAN rh-perl530-perl-App-cpanminus" && \

--- a/5.30/README.md
+++ b/5.30/README.md
@@ -4,7 +4,7 @@ Perl 5.30 container image
 This container image includes Perl 5.30 as an [S2I](https://github.com/openshift/source-to-image) base image for your Perl 5.30 applications.
 Users can choose between RHEL, CentOS and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -70,10 +70,10 @@ To use the Perl image in a Dockerfile, follow these steps:
 #### 1. Pull a base builder image to build on
 
 ```
-podman pull centos/perl-530-centos7
+podman pull quay.io/centos7/perl-530-centos7
 ```
 
-An CentOs image `centos/perl-530-centos7` is used in this example.
+An CentOs image `quay.io/centos7/perl-530-centos7` is used in this example.
 
 #### 2. Pull and application code
 
@@ -96,7 +96,7 @@ For all these three parts, users can either setup all manually and use commands 
 ##### 3.1 To use your own setup, create a Dockerfile with this content:
 
 ```
-FROM centos/perl-530-centos7
+FROM quay.io/centos7/perl-530-centos7
 
 # Add application sources
 ADD app-src .
@@ -120,7 +120,7 @@ CMD exec httpd -C 'Include /opt/app-root/etc/httpd.conf' -D FOREGROUND
 ##### 3.2 To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
 
 ```
-FROM centos/perl-530-centos7
+FROM quay.io/centos7/perl-530-centos7
 
 # Add application sources to a directory that the assemble scriptexpects them
 # and set permissions so that the container runs without root access

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Perl container images
-==================
+=====================
+
+s2i-perl-container 5.26: [![Docker Repository on Quay](https://quay.io/repository/centos7/perl-526-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/perl-526-centos7),
+s2i-perl-container 5.30: [![Docker Repository on Quay](https://quay.io/repository/centos7/perl-530-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/perl-530-centos7)
 
 This repository contains the source for building various versions of
 the Perl application as a reproducible container image using
@@ -17,7 +20,7 @@ For more information about concepts used in these container images, see the
 
 
 Versions
----------------
+--------
 Perl versions currently provided:
 * [perl-5.30](5.30)
 * [perl-5.26](5.26)
@@ -31,7 +34,7 @@ CentOS versions currently supported:
 
 
 Installation
----------------
+------------
 To build a Perl image, choose either the CentOS or RHEL based image:
 
 *  **RHEL based image**
@@ -57,7 +60,7 @@ To build a Perl image, choose either the CentOS or RHEL based image:
     This image is available on DockerHub. To download the perl-5.30 image, run:
 
     ```
-    $ podman pull centos/perl-530-centos7
+    $ podman pull docker.io/centos7/perl-530-centos7
     ```
 
     To build the perl-5.30 image from scratch run:
@@ -75,7 +78,7 @@ on all provided versions of Perl.**
 
 
 Usage
----------------------------------
+-----
 
 For information about usage of the Dockerfile for Perl 5.30,
 see [usage documentation](5.30/README.md).
@@ -84,7 +87,7 @@ For information about usage of the Dockerfile for Perl 5.30 - mod_fcgid version,
 see [usage documentation](5.30-mod_fcgid/README.md).
 
 Test
----------------------
+----
 This repository also provides a [S2I](https://github.com/openshift/source-to-image) test framework,
 which launches tests to check functionality of a simple Perl application built on top of the s2i-perl image.
 
@@ -112,7 +115,7 @@ on all of the provided versions of Perl.**
 
 
 Repository organization
-------------------------
+-----------------------
 * **`<perl-version>`**
 
     * **Dockerfile**
@@ -167,4 +170,3 @@ Repository organization
         * **run**
 
             This script runs the [S2I](https://github.com/openshift/source-to-image) test framework.
-


### PR DESCRIPTION
This commit adds support for Quay.io registry instead of Docker.io registry.
Docker.io registry adds rate limits which sometimes blocks our test suite.