### PR TITLE
Deprecate perl-5.26 imagestreams for RHEL7 and CentOS7

### DIFF
--- a/imagestreams/perl-centos.json
+++ b/imagestreams/perl-centos.json
@@ -107,46 +107,6 @@
         "referencePolicy": {
           "type": "Local"
         }
-      },
-      {
-        "name": "5.26-el7",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.26 (CentOS 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.26 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
-          "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "supports":"perl:5.26,perl",
-          "version": "5.26",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/centos7/perl-526-centos7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "5.26",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.26",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.26 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
-          "iconClass": "icon-perl",
-          "tags": "builder,perl,hidden",
-          "supports":"perl:5.26,perl",
-          "version": "5.26",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/centos7/perl-526-centos7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
       }
     ]
   }

--- a/imagestreams/perl-rhel.json
+++ b/imagestreams/perl-rhel.json
@@ -107,46 +107,6 @@
         "referencePolicy": {
           "type": "Local"
         }
-      },
-      {
-        "name": "5.26-el7",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.26 (RHEL 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.26 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
-              "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "supports":"perl:5.26,perl",
-          "version": "5.26",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/perl-526-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "5.26",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.26",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.26 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.",
-              "iconClass": "icon-perl",
-          "tags": "builder,perl,hidden",
-          "supports":"perl:5.26,perl",
-          "version": "5.26",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/perl-526-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
       }
     ]
   }


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>