### PR TITLE
Add support for Testing Farm CI

### DIFF
--- a/.github/workflows/centos7-openshift-tests.yaml
+++ b/.github/workflows/centos7-openshift-tests.yaml
@@ -1,0 +1,188 @@
+name: CentOS7-openshift-tests@TF
+
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  build:
+    # This job only runs for '[test]' pull request comments by owner, member
+    name: Schedule test on Testing Farm service for CentOS7 - Openshift
+    runs-on: ubuntu-20.04
+    if: |
+      github.event.issue.pull_request
+      && github.event.comment.body == '[test]'
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    outputs:
+      REQ_ID: ${{steps.sched_test.outputs.REQ_ID}}
+      SHA: ${{steps.sha.outputs.SHA}}
+    steps:
+      - name: Get pull request number
+        id: pr_nr
+        run: |
+          PR_URL="${{ github.event.comment.issue_url }}"
+          echo "::set-output name=PR_NR::${PR_URL##*/}"
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
+
+      - name: Get sha
+        id: sha
+        run: |
+          echo "::set-output name=SHA::$(git rev-parse HEAD)"
+
+      - name: Create status check to pending
+        id: pending
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat << EOF > pending.json
+          {
+            "sha": "${{steps.sha.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm - CentOS7 - OpenShift 3",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/pipeline.log"
+          }
+          EOF
+          echo "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}}"
+          curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}} \
+            --data @pending.json
+          echo "::set-output name=GITHUB_REPOSITORY::$GITHUB_REPOSITORY"
+
+      - name: Schedule a test on Testing Farm forn CentOS7 - OpenShift 3
+        id: sched_test
+        run: |
+          apt update && apt -y install curl jq
+          cat << EOF > request.json
+          {
+            "api_key": "${{ secrets.TF_PUBLIC_API_KEY }}",
+            "test": {"fmf": {
+              "url": "https://github.com/sclorg/sclorg-testing-farm",
+              "ref": "main"
+            }},
+            "environments": [{
+              "arch": "x86_64",
+              "os": {"compose": "CentOS-7"},
+              "variables": {
+                "REPO_URL": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
+                "REPO_NAME": "$GITHUB_REPOSITORY",
+                "PR_NUMBER": "${{ steps.pr_nr.outputs.PR_NR }}",
+                "OS": "centos7",
+                "TEST_NAME": "test-openshift"
+              }
+            }]
+          }
+          EOF
+          curl ${{ secrets.TF_ENDPOINT }}/requests --data @request.json --header "Content-Type: application/json" --output response.json
+          echo "::set-output name=REQ_ID::$(jq -r .id response.json)"
+
+#      - name: Add comment with Testing Farm request/result
+#        # This step adds a new comment to the pull request with a link to the test.
+#        # TODO: This is a temporary workaround until a proper way to set a commit status is implemented.
+#        id: comment
+#        uses: peter-evans/create-or-update-comment@v1
+#        if: always()
+#        with:
+#          issue-number: ${{ steps.pr_nr.outputs.PR_NR }}
+#          body: |
+#            Testing Farm - CentOS 7 [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.sched_test.outputs.req_id }})
+#            for CentOS 7 test was created. Once finished, results should be available [here](http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/)
+#            [Full pipeline log](http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/pipeline.log)
+
+  running:
+    needs: build
+    name: Check running tests on Testing Farm service
+    runs-on: ubuntu-20.04
+    outputs:
+      REQ_ID: ${{steps.req_sha.outputs.REQ_ID}}
+      SHA: ${{steps.req_sha.outputs.SHA}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check if REQ_ID and SHA exists
+        id: req_sha
+        run: |
+          apt update && apt -y install curl jq
+          echo "::set-output name=REQ_ID::${{needs.build.outputs.REQ_ID}}"
+          echo "::set-output name=SHA::${{needs.build.outputs.SHA}}"
+
+      - name: Switch to running state of Testing Farm request
+        id: running
+        run: |
+          cat << EOF > running.json
+          {
+            "sha": "${{needs.build.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm - CentOS7 - OpenShift 3",
+            "description": "Build started",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ needs.build.outputs.REQ_ID }}/"
+          }
+          EOF
+          curl -X POST -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.build.outputs.SHA}} \
+            --data @running.json
+
+      - name: Check test is still running
+        id: still_running
+        run: |
+          CMD=${{ secrets.TF_ENDPOINT }}/requests/${{needs.build.outputs.REQ_ID}}
+          curl $CMD > job.json
+          state=$(jq -r .state job.json)
+          while [ "$state" == "running" ] || [ "$state" == "new" ] || [ "$state" == "pending" ] || [ "$state" == "queued" ]; do
+            sleep 30
+            curl $CMD > job.json
+            state=$(jq -r .state job.json)
+          done
+
+  finish:
+    needs: running
+    name: Tests are finished - switching to proper state
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check if REQ_ID exists
+        run: echo "${{ needs.running.outputs.REQ_ID }}"
+
+      - name: Check if SHA exists
+        run: echo "${{ needs.running.outputs.SHA }}"
+
+      - name: Get final state of Testing Farm request
+        id: final_state
+        run: |
+          apt update && apt -y install curl jq
+          curl ${{ secrets.TF_ENDPOINT }}/requests/${{needs.running.outputs.REQ_ID}} > job.json
+          cat job.json
+          state=$(jq -r .state job.json)
+          result=$(jq -r .result.overall job.json)
+          new_state="success"
+          infra_error=" "
+          echo "State is $state and result is: $result"
+          if [ "$state" == "complete" ]; then
+            if [ "$result" != "passed" ]; then
+              new_state="failure"
+            fi
+          else
+            infra_error=" - Infra problems"
+            new_state="failure"
+          fi
+          echo "New State is: $new_state"
+          echo "Infra state is: $infra_error"
+          echo "::set-output name=FINAL_STATE::$new_state"
+          echo "::set-output name=INFRA_STATE::$infra_error"
+
+      - name: Switch to final state of Testing Farm request
+        run: |
+          cat << EOF > final.json
+          {
+            "sha": "${{needs.running.outputs.SHA}}",
+            "state": "${{steps.final_state.outputs.FINAL_STATE}}",
+            "context": "Testing Farm - CentOS7 - OpenShift 3",
+            "description": "Build finished${{steps.final_state.outputs.INFRA_STATE}}",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ needs.running.outputs.REQ_ID }}/"
+          }
+          EOF
+          cat final.json
+          curl -X POST -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.running.outputs.SHA}} \
+            --data @final.json

--- a/.github/workflows/centos7-tests.yaml
+++ b/.github/workflows/centos7-tests.yaml
@@ -1,0 +1,188 @@
+name: CentOS7-tests@TF
+
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  build:
+    # This job only runs for '[test]' pull request comments by owner, member
+    name: Schedule test on Testing Farm service for CentOS7
+    runs-on: ubuntu-20.04
+    if: |
+      github.event.issue.pull_request
+      && github.event.comment.body == '[test]'
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    outputs:
+      REQ_ID: ${{steps.sched_test.outputs.REQ_ID}}
+      SHA: ${{steps.sha.outputs.SHA}}
+    steps:
+      - name: Get pull request number
+        id: pr_nr
+        run: |
+          PR_URL="${{ github.event.comment.issue_url }}"
+          echo "::set-output name=PR_NR::${PR_URL##*/}"
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
+
+      - name: Get sha
+        id: sha
+        run: |
+          echo "::set-output name=SHA::$(git rev-parse HEAD)"
+
+      - name: Create status check to pending
+        id: pending
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat << EOF > pending.json
+          {
+            "sha": "${{steps.sha.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm - CentOS7",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/pipeline.log"
+          }
+          EOF
+          echo "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}}"
+          curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}} \
+            --data @pending.json
+          echo "::set-output name=GITHUB_REPOSITORY::$GITHUB_REPOSITORY"
+
+      - name: Schedule a test on Testing Farm
+        id: sched_test
+        run: |
+          apt update && apt -y install curl jq
+          cat << EOF > request.json
+          {
+            "api_key": "${{ secrets.TF_PUBLIC_API_KEY }}",
+            "test": {"fmf": {
+              "url": "https://github.com/sclorg/sclorg-testing-farm",
+              "ref": "main"
+            }},
+            "environments": [{
+              "arch": "x86_64",
+              "os": {"compose": "CentOS-7"},
+              "variables": {
+                "REPO_URL": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
+                "REPO_NAME": "$GITHUB_REPOSITORY",
+                "PR_NUMBER": "${{ steps.pr_nr.outputs.PR_NR }}",
+                "OS": "centos7",
+                "TEST_NAME": "test"
+              }
+            }]
+          }
+          EOF
+          curl ${{ secrets.TF_ENDPOINT }}/requests --data @request.json --header "Content-Type: application/json" --output response.json
+          echo "::set-output name=REQ_ID::$(jq -r .id response.json)"
+
+#      - name: Add comment with Testing Farm request/result
+#        # This step adds a new comment to the pull request with a link to the test.
+#        # TODO: This is a temporary workaround until a proper way to set a commit status is implemented.
+#        id: comment
+#        uses: peter-evans/create-or-update-comment@v1
+#        if: always()
+#        with:
+#          issue-number: ${{ steps.pr_nr.outputs.PR_NR }}
+#          body: |
+#            Testing Farm - CentOS 7 [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.sched_test.outputs.req_id }})
+#            for CentOS 7 test was created. Once finished, results should be available [here](http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/)
+#            [Full pipeline log](http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/pipeline.log)
+
+  running:
+    needs: build
+    name: Check running tests on Testing Farm service
+    runs-on: ubuntu-20.04
+    outputs:
+      REQ_ID: ${{steps.req_sha.outputs.REQ_ID}}
+      SHA: ${{steps.req_sha.outputs.SHA}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check if REQ_ID and SHA exists
+        id: req_sha
+        run: |
+          apt update && apt -y install curl jq
+          echo "::set-output name=REQ_ID::${{needs.build.outputs.REQ_ID}}"
+          echo "::set-output name=SHA::${{needs.build.outputs.SHA}}"
+
+      - name: Switch to running state of Testing Farm request
+        id: running
+        run: |
+          cat << EOF > running.json
+          {
+            "sha": "${{needs.build.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm - CentOS7",
+            "description": "Build started",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ needs.build.outputs.REQ_ID }}/"
+          }
+          EOF
+          curl -X POST -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.build.outputs.SHA}} \
+            --data @running.json
+
+      - name: Check test is still running
+        id: still_running
+        run: |
+          CMD=${{ secrets.TF_ENDPOINT }}/requests/${{needs.build.outputs.REQ_ID}}
+          curl $CMD > job.json
+          state=$(jq -r .state job.json)
+          while [ "$state" == "running" ] || [ "$state" == "new" ] || [ "$state" == "pending" ] || [ "$state" == "queued" ]; do
+            sleep 30
+            curl $CMD > job.json
+            state=$(jq -r .state job.json)
+          done
+
+  finish:
+    needs: running
+    name: Tests are finished - switching to proper state
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check if REQ_ID exists
+        run: echo "${{ needs.running.outputs.REQ_ID }}"
+
+      - name: Check if SHA exists
+        run: echo "${{ needs.running.outputs.SHA }}"
+
+      - name: Get final state of Testing Farm request
+        id: final_state
+        run: |
+          apt update && apt -y install curl jq
+          curl ${{ secrets.TF_ENDPOINT }}/requests/${{needs.running.outputs.REQ_ID}} > job.json
+          cat job.json
+          state=$(jq -r .state job.json)
+          result=$(jq -r .result.overall job.json)
+          new_state="success"
+          infra_error=" "
+          echo "State is $state and result is: $result"
+          if [ "$state" == "complete" ]; then
+            if [ "$result" != "passed" ]; then
+              new_state="failure"
+            fi
+          else
+            infra_error=" - Infra problems"
+            new_state="failure"
+          fi
+          echo "New State is: $new_state"
+          echo "Infra state is: $infra_error"
+          echo "::set-output name=FINAL_STATE::$new_state"
+          echo "::set-output name=INFRA_STATE::$infra_error"
+
+      - name: Switch to final state of Testing Farm request
+        run: |
+          cat << EOF > final.json
+          {
+            "sha": "${{needs.running.outputs.SHA}}",
+            "state": "${{steps.final_state.outputs.FINAL_STATE}}",
+            "context": "Testing Farm - CentOS7",
+            "description": "Build finished${{steps.final_state.outputs.INFRA_STATE}}",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ needs.running.outputs.REQ_ID }}/"
+          }
+          EOF
+          cat final.json
+          curl -X POST -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.running.outputs.SHA}} \
+            --data @final.json

--- a/.github/workflows/fedora-tests.yaml
+++ b/.github/workflows/fedora-tests.yaml
@@ -1,0 +1,189 @@
+name: Fedora-tests@TF
+
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  build:
+    # This job only runs for '[test]' pull request comments by owner, member
+    name: Schedule test on Testing Farm service for Fedora
+    runs-on: ubuntu-20.04
+    if: |
+      github.event.issue.pull_request
+      && github.event.comment.body == '[test]'
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    outputs:
+      REQ_ID: ${{steps.sched_test.outputs.REQ_ID}}
+      SHA: ${{steps.sha.outputs.SHA}}
+    steps:
+      - name: Get pull request number
+        id: pr_nr
+        run: |
+          PR_URL="${{ github.event.comment.issue_url }}"
+          echo "::set-output name=PR_NR::${PR_URL##*/}"
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
+
+      - name: Get sha
+        id: sha
+        run: |
+          echo "::set-output name=SHA::$(git rev-parse HEAD)"
+
+      - name: Create status check to pending
+        id: pending
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat << EOF > pending.json
+          {
+            "sha": "${{steps.sha.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm - Fedora"
+          }
+          EOF
+          echo "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}}"
+          curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{steps.sha.outputs.SHA}} \
+            --data @pending.json
+          echo "::set-output name=GITHUB_REPOSITORY::$GITHUB_REPOSITORY"
+
+      - name: Schedule a test on Testing Farm
+        id: sched_test
+        run: |
+          apt update && apt -y install curl jq
+          cat << EOF > request.json
+          {
+            "api_key": "${{ secrets.TF_PUBLIC_API_KEY }}",
+            "test": {"fmf": {
+              "url": "https://github.com/sclorg/sclorg-testing-farm",
+              "ref": "main"
+            }},
+            "environments": [{
+              "arch": "x86_64",
+              "os": {"compose": "CentOS-7"},
+              "variables": {
+                "REPO_URL": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
+                "REPO_NAME": "$GITHUB_REPOSITORY",
+                "PR_NUMBER": "${{ steps.pr_nr.outputs.PR_NR }}",
+                "OS": "fedora",
+                "TEST_NAME": "test"
+              }
+            }]
+          }
+          EOF
+          curl ${{ secrets.TF_ENDPOINT }}/requests --data @request.json --header "Content-Type: application/json" --output response.json
+          echo "::set-output name=REQ_ID::$(jq -r .id response.json)"
+
+#      - name: Add comment with Testing Farm request/result
+#        # This step adds a new comment to the pull request with a link to the test.
+#        # TODO: This is a temporary workaround until a proper way to set a commit status is implemented.
+#        id: comment
+#        uses: peter-evans/create-or-update-comment@v1
+#        if: always()
+#        with:
+#          issue-number: ${{ steps.pr_nr.outputs.PR_NR }}
+#          body: |
+#            Testing Farm - Fedora [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.sched_test.outputs.REQ_ID }})
+#            for Fedora test was created. Once finished, results should be available [here](http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.req_id }}/)
+#            [Full pipeline log](http://artifacts.dev.testing-farm.io/${{ steps.sched_test.outputs.REQ_ID }}/pipeline.log)
+
+  running:
+    needs: build
+    name: Check running tests on Testing Farm service
+    runs-on: ubuntu-20.04
+    outputs:
+      REQ_ID: ${{steps.req_sha.outputs.REQ_ID}}
+      SHA: ${{steps.req_sha.outputs.SHA}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check if REQ_ID and SHA exists
+        id: req_sha
+        run: |
+          apt update && apt -y install curl jq
+          echo "::set-output name=REQ_ID::${{needs.build.outputs.REQ_ID}}"
+          echo "::set-output name=SHA::${{needs.build.outputs.SHA}}"
+
+      - name: Switch to running state of Testing Farm request
+        id: running
+        run: |
+          cat << EOF > running.json
+          {
+            "sha": "${{needs.build.outputs.SHA}}",
+            "state": "pending",
+            "context": "Testing Farm - Fedora",
+            "description": "Build started",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ needs.build.outputs.REQ_ID }}/"
+          }
+          EOF
+          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN}}" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.build.outputs.SHA}} \
+            --data @running.json
+
+      - name: Check test is still running
+        id: still_running
+        run: |
+          CMD=${{ secrets.TF_ENDPOINT }}/requests/${{needs.build.outputs.REQ_ID}}
+          curl $CMD > job.json
+          cat job.json
+          state=$(jq -r .state job.json)
+          while [ "$state" == "running" ] || [ "$state" == "new" ] || [ "$state" == "pending" ] || [ "$state" == "queued" ]; do
+            sleep 30
+            curl $CMD > job.json
+            cat job.json
+            state=$(jq -r .state job.json)
+          done
+
+  finish:
+    needs: running
+    name: Tests are finished - switching to proper state
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check if REQ_ID exists
+        run: echo "${{ needs.running.outputs.REQ_ID }}"
+
+      - name: Check if SHA exists
+        run: echo "${{ needs.running.outputs.SHA }}"
+
+      - name: Get final state of Testing Farm request
+        id: final_state
+        run: |
+          apt update && apt -y install curl jq
+          curl ${{ secrets.TF_ENDPOINT }}/requests/${{needs.running.outputs.REQ_ID}} > job.json
+          cat job.json
+          state=$(jq -r .state job.json)
+          result=$(jq -r .result.overall job.json)
+          new_state="success"
+          infra_error=" "
+          echo "State is $state and result is: $result"
+          if [ "$state" == "complete" ]; then
+            if [ "$result" != "passed" ]; then
+              new_state="failure"
+            fi
+          else
+            infra_error=" - Infra problems"
+            new_state="failure"
+          fi
+          echo "New State is: $new_state"
+          echo "Infra state is: $infra_error"
+          echo "::set-output name=FINAL_STATE::$new_state"
+          echo "::set-output name=INFRA_STATE::$infra_error"
+
+      - name: Switch to final state of Testing Farm request
+        run: |
+          cat << EOF > final.json
+          {
+            "sha": "${{needs.running.outputs.SHA}}",
+            "state": "${{steps.final_state.outputs.FINAL_STATE}}",
+            "context": "Testing Farm - Fedora",
+            "description": "Build finished${{steps.final_state.outputs.INFRA_STATE}}",
+            "target_url": "http://artifacts.dev.testing-farm.io/${{ needs.running.outputs.REQ_ID }}/"
+          }
+          EOF
+          cat final.json
+          curl -X POST -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/${{needs.running.outputs.SHA}} \
+            --data @final.json


### PR DESCRIPTION
This pull request adds support for testing s2i-perl-container in Testing Farm

Supported scenarios are:

Fedora
CentOS7
CentOS7 with OpenShift

How does it work?
As soon as a pull request is created, when the owner or member writes the comment [test], then Testing Farm is scheduled.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>