### PR TITLE
Remove obsolete information about PERL_APACHE2_RELOAD variable

### DIFF
--- a/5.26-mod_fcgid/README.md
+++ b/5.26-mod_fcgid/README.md
@@ -176,10 +176,6 @@ file inside your source code repository.
     This variable specifies a mirror URL which will used by cpanminus to install dependencies.
     By default the URL is not specified.
 
-* **PERL_APACHE2_RELOAD**
-
-    Set this to "true" to enable automatic reloading of modified Perl modules.
-
 * **HTTPD_START_SERVERS**
 
     The [StartServers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#startservers)

--- a/5.30-mod_fcgid/README.md
+++ b/5.30-mod_fcgid/README.md
@@ -176,10 +176,6 @@ file inside your source code repository.
     This variable specifies a mirror URL which will used by cpanminus to install dependencies.
     By default the URL is not specified.
 
-* **PERL_APACHE2_RELOAD**
-
-    Set this to "true" to enable automatic reloading of modified Perl modules.
-
 * **HTTPD_START_SERVERS**
 
     The [StartServers](https://httpd.apache.org/docs/2.4/mod/mpm_common.html#startservers)


### PR DESCRIPTION
This variable doesn't exist in FCGI version.