### PR TITLE
Fix two bash warnings

### DIFF
--- a/test/run
+++ b/test/run
@@ -9,8 +9,8 @@
 IMAGE_NAME=${IMAGE_NAME-centos/perl-530-centos7-candidate}
 
 # TODO: Make command compatible for Mac users
-test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
-image_dir=$(readlink -zf ${test_dir}/..)
+test_dir="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))"
+image_dir=$(readlink -f ${test_dir}/..)
 test_short_summary=''
 TESTSUITE_RESULT=0
 TEST_LIST="\

--- a/test/run-modfcgid
+++ b/test/run-modfcgid
@@ -9,8 +9,8 @@
 IMAGE_NAME=${IMAGE_NAME-centos/perl-530-centos7-candidate}
 
 # TODO: Make command compatible for Mac users
-test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
-image_dir=$(readlink -zf ${test_dir}/..)
+test_dir="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))"
+image_dir=$(readlink -f ${test_dir}/..)
 test_short_summary=''
 TESTSUITE_RESULT=0
 TEST_LIST="\


### PR DESCRIPTION
When calling readline do not use the -z option.
From the readline manpage
           -z, --zero
                  end each output line with NUL, not newline

This fixes the following two bash warnings

test/run: line 11: warning: command substitution: ignored null byte in
input
test/run: line 12: warning: command substitution: ignored null byte in
input