### PR TITLE
Use groupified apiVersion

### DIFF
--- a/imagestreams/perl-centos.json
+++ b/imagestreams/perl-centos.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "perl",
     "annotations": {

--- a/imagestreams/perl-rhel-aarch64.json
+++ b/imagestreams/perl-rhel-aarch64.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "perl",
     "annotations": {

--- a/imagestreams/perl-rhel.json
+++ b/imagestreams/perl-rhel.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "perl",
     "annotations": {


### PR DESCRIPTION
Non-groupified objects were deprecated in OCP 4.7.
