### PR TITLE
Use generic run tests

### DIFF
--- a/test/run-modfcgid
+++ b/test/run-modfcgid
@@ -11,8 +11,7 @@ IMAGE_NAME=${IMAGE_NAME-centos/perl-530-centos7-candidate}
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -f ${test_dir}/..)
-test_short_summary=''
-TESTSUITE_RESULT=0
+
 TEST_LIST="\
 test_sample_test_app
 test_binpath
@@ -28,6 +27,7 @@ test_from_dockerfile
 
 
 source "${test_dir}/test-lib.sh"
+ct_enable_cleanup
 
 # TODO: This should be part of the image metadata
 test_port=8080
@@ -434,33 +434,6 @@ function test_from_dockerfile(){
   check_result $t2
 }
 
-function run_all_tests() {
-  for test_case in $TEST_LIST; do
-    : "Running test $test_case ...."
-    TESTCASE_RESULT=0
-    $test_case
-    check_result $?
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    printf -v test_short_summary "%s %s %s\n" "${test_short_summary}" "${test_msg}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && return 1
-  done;
-}
-
 # Run the chosen tests
-TEST_LIST=${TESTS:-$TEST_LIST} run_all_tests
-
-echo "$test_short_summary"
-
-if [ $TESTSUITE_RESULT -eq 0 ] ; then
-  echo "Tests for ${IMAGE_NAME} succeeded."
-else
-  echo "Tests for ${IMAGE_NAME} failed."
-fi
-
-exit $TESTSUITE_RESULT
+TEST_SUMARRY=''
+TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset


### PR DESCRIPTION
The `ct_run_tests_from_testset` is already used in `test/run` file.
This PR proposes to use it also in `test/run-modfcgid`