### PR TITLE
Support for CVP pipeline

### DIFF
--- a/5.26-mod_fcgid/test/test-openshift.yaml
+++ b/5.26-mod_fcgid/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/5.26/test/test-openshift.yaml
+++ b/5.26/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/5.30-mod_fcgid/test/test-openshift.yaml
+++ b/5.30-mod_fcgid/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/5.30/test/test-openshift.yaml
+++ b/5.30/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/5.32/test/test-openshift.yaml
+++ b/5.32/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/5.34/test/test-openshift.yaml
+++ b/5.34/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../../test/test-openshift.yaml

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -29,6 +29,8 @@ ct_os_check_compulsory_vars
 
 ct_os_check_login || exit 1
 
+ct_os_tag_image_for_cvp "perl"
+
 set -u
 
 # For testing on OpenShift 4 we use internal registry

--- a/test/test-lib-perl.sh
+++ b/test/test-lib-perl.sh
@@ -14,7 +14,7 @@ source "${THISDIR}/test-lib-openshift.sh"
 # Check the imagestream
 function test_perl_imagestream() {
   case ${OS} in
-    rhel7|centos7) ;;
+    rhel7|centos7|rhel8) ;;
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 

--- a/test/test-openshift.yaml
+++ b/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../common/test-openshift.yaml


### PR DESCRIPTION
This pull request adds support for testing perl-container in CVP pipeline.

The changes are this one:
* `common` directory updated to the latest
* `test/test-openshift.yaml` is the symlink from `common`
* Each version has as well symlink from `test/test-openshift.yaml`
* support testing imagestream in `test-lib-perl.sh`
* tagging image for CVP pipeline in `run-openshift-remote-cluster`