### PR TITLE
Add a test in Dockerfile directly to check the version

### DIFF
--- a/5.26-mod_fcgid/Dockerfile.rhel8
+++ b/5.26-mod_fcgid/Dockerfile.rhel8
@@ -42,6 +42,7 @@ RUN INSTALL_PKGS="perl perl-devel mod_fcgid perl-App-cpanminus perl-FCGI patch" 
     yum -y --allowerasing distrosync && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/5.26/Dockerfile.fedora
+++ b/5.26/Dockerfile.fedora
@@ -36,6 +36,7 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="perl perl-devel mod_perl perl-CPAN perl-App-cpanminus httpd python2" && \
     dnf install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     dnf clean all
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/5.30-mod_fcgid/Dockerfile.rhel8
+++ b/5.30-mod_fcgid/Dockerfile.rhel8
@@ -42,6 +42,7 @@ RUN INSTALL_PKGS="perl perl-devel mod_fcgid perl-App-cpanminus perl-FCGI patch" 
     yum -y --allowerasing distrosync && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/5.30/Dockerfile.fedora
+++ b/5.30/Dockerfile.fedora
@@ -38,6 +38,7 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="perl perl-devel mod_perl perl-CPAN perl-App-cpanminus httpd python2" && \
     dnf install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     dnf clean all
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/5.32/Dockerfile.c9s
+++ b/5.32/Dockerfile.c9s
@@ -39,6 +39,7 @@ RUN INSTALL_PKGS="perl perl-devel mod_fcgid perl-App-cpanminus perl-FCGI patch" 
     yum -y --allowerasing distrosync && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/5.32/Dockerfile.fedora
+++ b/5.32/Dockerfile.fedora
@@ -39,6 +39,7 @@ RUN INSTALL_PKGS="perl perl-devel mod_fcgid perl-App-cpanminus perl-FCGI patch" 
     dnf -y module enable perl:$PERL_VERSION && \
     dnf install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     dnf -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/5.32/Dockerfile.rhel9
+++ b/5.32/Dockerfile.rhel9
@@ -39,6 +39,7 @@ RUN INSTALL_PKGS="perl perl-devel mod_fcgid perl-App-cpanminus perl-FCGI patch" 
     yum -y --allowerasing distrosync && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/5.34/Dockerfile.c9s
+++ b/5.34/Dockerfile.c9s
@@ -39,6 +39,7 @@ RUN INSTALL_PKGS="perl perl-devel mod_fcgid perl-App-cpanminus perl-FCGI patch" 
     yum -y --allowerasing distrosync && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/5.34/Dockerfile.fedora
+++ b/5.34/Dockerfile.fedora
@@ -39,6 +39,7 @@ RUN INSTALL_PKGS="perl perl-devel mod_fcgid perl-App-cpanminus perl-FCGI patch" 
     dnf -y module enable perl:$PERL_VERSION && \
     dnf install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    perl -v | grep -qe "v$PERL_VERSION\." && echo "Found VERSION $PERL_VERSION" && \
     dnf -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH


### PR DESCRIPTION
Otherwise when a wrong stream is installed, it's only found by scl test, which is too late in the process and might even go through uncought, especially when the scl test is removed for non-SCL distros at some point.