### PR TITLE
Remove 5.30 imagestreams

### DIFF
--- a/imagestreams/perl-centos.json
+++ b/imagestreams/perl-centos.json
@@ -69,26 +69,6 @@
         }
       },
       {
-        "name": "5.30-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.30 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.30 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30-mod_fcgid/README.md.",
-              "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "supports":"perl:5.30,perl",
-          "version": "5.30",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/perl-530:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "5.30-el7",
         "annotations": {
           "openshift.io/display-name": "Perl 5.30 (CentOS 7)",

--- a/imagestreams/perl-rhel-aarch64.json
+++ b/imagestreams/perl-rhel-aarch64.json
@@ -69,26 +69,6 @@
         }
       },
       {
-        "name": "5.30-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.30 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.30 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30-mod_fcgid/README.md.",
-              "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "supports":"perl:5.30,perl",
-          "version": "5.30",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/perl-530:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "5.26-ubi8",
         "annotations": {
           "openshift.io/display-name": "Perl 5.26 (UBI 8)",

--- a/imagestreams/perl-rhel.json
+++ b/imagestreams/perl-rhel.json
@@ -69,26 +69,6 @@
         }
       },
       {
-        "name": "5.30-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.30 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.30 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30-mod_fcgid/README.md.",
-              "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "supports":"perl:5.30,perl",
-          "version": "5.30",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/perl-530:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "5.30-el7",
         "annotations": {
           "openshift.io/display-name": "Perl 5.30 (RHEL 7)",


### PR DESCRIPTION
Perl 5.30 went EOL in November 2023: https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle

@yselkowitz FYI if you don't mind looking at the changes

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
