### PR TITLE
Add PyTest  suite for testing perl container in OpenShift 4

### DIFF
--- a/5.26-mod_fcgid/test/run-openshift
+++ b/5.26-mod_fcgid/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/5.26-mod_fcgid/test/run-openshift-pytest
+++ b/5.26-mod_fcgid/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/5.26-mod_fcgid/test/test_dancer_ex_standalone.py
+++ b/5.26-mod_fcgid/test/test_dancer_ex_standalone.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone.py

--- a/5.26-mod_fcgid/test/test_dancer_ex_templates.py
+++ b/5.26-mod_fcgid/test/test_dancer_ex_templates.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates.py

--- a/5.26-mod_fcgid/test/test_deploy_templates.py
+++ b/5.26-mod_fcgid/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/5.26-mod_fcgid/test/test_imagestreams_quickstart.py
+++ b/5.26-mod_fcgid/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/5.26-mod_fcgid/test/test_latest_imagestreams.py
+++ b/5.26-mod_fcgid/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/5.26/test/run-openshift
+++ b/5.26/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/5.26/test/run-openshift-pytest
+++ b/5.26/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/5.26/test/test_dancer_ex_standalone.py
+++ b/5.26/test/test_dancer_ex_standalone.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone.py

--- a/5.26/test/test_dancer_ex_templates.py
+++ b/5.26/test/test_dancer_ex_templates.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates.py

--- a/5.26/test/test_deploy_templates.py
+++ b/5.26/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/5.26/test/test_imagestreams_quickstart.py
+++ b/5.26/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/5.26/test/test_latest_imagestreams.py
+++ b/5.26/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/5.30-mod_fcgid/test/run-openshift
+++ b/5.30-mod_fcgid/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/5.30-mod_fcgid/test/run-openshift-pytest
+++ b/5.30-mod_fcgid/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/5.30-mod_fcgid/test/test_dancer_ex_standalone.py
+++ b/5.30-mod_fcgid/test/test_dancer_ex_standalone.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone.py

--- a/5.30-mod_fcgid/test/test_dancer_ex_templates.py
+++ b/5.30-mod_fcgid/test/test_dancer_ex_templates.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates.py

--- a/5.30-mod_fcgid/test/test_deploy_templates.py
+++ b/5.30-mod_fcgid/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/5.30-mod_fcgid/test/test_imagestreams_quickstart.py
+++ b/5.30-mod_fcgid/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/5.30-mod_fcgid/test/test_latest_imagestreams.py
+++ b/5.30-mod_fcgid/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/5.30/test/run-openshift
+++ b/5.30/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/5.30/test/run-openshift-pytest
+++ b/5.30/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/5.30/test/test_dancer_ex_standalone.py
+++ b/5.30/test/test_dancer_ex_standalone.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone.py

--- a/5.30/test/test_dancer_ex_templates.py
+++ b/5.30/test/test_dancer_ex_templates.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates.py

--- a/5.30/test/test_deploy_templates.py
+++ b/5.30/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/5.30/test/test_imagestreams_quickstart.py
+++ b/5.30/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/5.30/test/test_latest_imagestreams.py
+++ b/5.30/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/5.32/test/run-openshift
+++ b/5.32/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/5.32/test/run-openshift-pytest
+++ b/5.32/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/5.32/test/test_dancer_ex_standalone.py
+++ b/5.32/test/test_dancer_ex_standalone.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone.py

--- a/5.32/test/test_dancer_ex_templates.py
+++ b/5.32/test/test_dancer_ex_templates.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates.py

--- a/5.32/test/test_deploy_templates.py
+++ b/5.32/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/5.32/test/test_imagestreams_quickstart.py
+++ b/5.32/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/5.32/test/test_latest_imagestreams.py
+++ b/5.32/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/5.34/test/run-openshift
+++ b/5.34/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/5.34/test/run-openshift-pytest
+++ b/5.34/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/5.34/test/test_dancer_ex_standalone.py
+++ b/5.34/test/test_dancer_ex_standalone.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone.py

--- a/5.34/test/test_dancer_ex_templates.py
+++ b/5.34/test/test_dancer_ex_templates.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates.py

--- a/5.34/test/test_deploy_templates.py
+++ b/5.34/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/5.34/test/test_imagestreams_quickstart.py
+++ b/5.34/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/5.34/test/test_latest_imagestreams.py
+++ b/5.34/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/5.36/test/run-openshift
+++ b/5.36/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/5.36/test/run-openshift-pytest
+++ b/5.36/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/5.36/test/test_dancer_ex_standalone.py
+++ b/5.36/test/test_dancer_ex_standalone.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone.py

--- a/5.36/test/test_dancer_ex_templates.py
+++ b/5.36/test/test_dancer_ex_templates.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates.py

--- a/5.36/test/test_deploy_templates.py
+++ b/5.36/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/5.36/test/test_imagestreams_quickstart.py
+++ b/5.36/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/5.36/test/test_latest_imagestreams.py
+++ b/5.36/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/5.38/test/run-openshift
+++ b/5.38/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/5.38/test/run-openshift-pytest
+++ b/5.38/test/run-openshift-pytest
@@ -1,0 +1,1 @@
+../../test/run-openshift-pytest

--- a/5.38/test/test_dancer_ex_standalone.py
+++ b/5.38/test/test_dancer_ex_standalone.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_standalone.py

--- a/5.38/test/test_dancer_ex_templates.py
+++ b/5.38/test/test_dancer_ex_templates.py
@@ -1,0 +1,1 @@
+../../test/test_dancer_ex_templates.py

--- a/5.38/test/test_deploy_templates.py
+++ b/5.38/test/test_deploy_templates.py
@@ -1,0 +1,1 @@
+../../test/test_deploy_templates.py

--- a/5.38/test/test_imagestreams_quickstart.py
+++ b/5.38/test/test_imagestreams_quickstart.py
@@ -1,0 +1,1 @@
+../../test/test_imagestreams_quickstart.py

--- a/5.38/test/test_latest_imagestreams.py
+++ b/5.38/test/test_latest_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_latest_imagestreams.py

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -38,7 +38,7 @@
     custom_tags:
       - name: "5.30"
         distro: UBI 7
-        app_version: ["5.30"]
+        app_version: "5.30"
 
   - filename: perl-rhel-aarch64.json
     latest: "5.32-ubi8"

--- a/imagestreams/perl-rhel.json
+++ b/imagestreams/perl-rhel.json
@@ -88,17 +88,17 @@
       {
         "name": "5.30",
         "annotations": {
-          "openshift.io/display-name": "Perl ['5.30'] (UBI 7)",
+          "openshift.io/display-name": "Perl 5.30 (UBI 7)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl ['5.30'] applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/['5.30']/README.md.",
+          "description": "Build and run Perl 5.30 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
           "iconClass": "icon-perl",
           "tags": "builder,perl",
-          "version": "['5.30']",
+          "version": "5.30",
           "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/perl-['530']:latest"
+          "name": "registry.redhat.io/ubi7/perl-530:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -8,4 +8,4 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-cd "${THISDIR}" && python3 -m pytest -s -rxfapP --showlocals -vv test_*.py
+cd "${THISDIR}" && python3 -m pytest -s -rA --showlocals -vv test_*.py

--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -8,4 +8,4 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-cd "${THISDIR}" && python3 -m pytest --showlocals -vv test_*.py
+cd "${THISDIR}" && python3 -m pytest -s -rxfapP --showlocals -vv test_*.py

--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+# VERSION specifies the major version of the MariaDB in format of X.Y
+# OS specifies RHEL version (e.g. OS=rhel7)
+#
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+
+cd "${THISDIR}" && python3 -m pytest --showlocals -vv test_*.py

--- a/test/test_dancer_ex_standalone.py
+++ b/test/test_dancer_ex_standalone.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+import pytest
+
+from container_ci_suite.utils import check_variables
+from container_ci_suite.openshift import OpenShiftAPI
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+
+
+# Replacement with 'test_python_s2i_app_ex'
+class TestPerlDancerExTemplate:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    def test_dancer_ex_template_inside_cluster(self):
+        service_name = "perl-testing"
+        assert self.oc_api.deploy_s2i_app(
+            image_name=IMAGE_NAME, app=f"https://github.com/sclorg/dancer-ex.git",
+            context=".",
+            service_name=service_name
+        )
+        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template=service_name, expected_output="Welcome to your Dancer application on OpenShift"
+        )

--- a/test/test_dancer_ex_templates.py
+++ b/test/test_dancer_ex_templates.py
@@ -1,0 +1,89 @@
+import os
+import sys
+
+import pytest
+from container_ci_suite.openshift import OpenShiftAPI
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+
+DEPLOYED_MYSQL_IMAGE = "quay.io/sclorg/mysql-80-c9s:c9s"
+
+MYSQL_TAGS = {
+    "rhel8": "-el8",
+    "rhel9": "-el9"
+}
+MYSQL_TAG = MYSQL_TAGS.get(OS, None)
+IMAGE_TAG = f"mysql:8.0{MYSQL_TAG}"
+MYSQL_VERSION = f"8.0{MYSQL_TAG}"
+
+
+class TestDeployDancerExTemplateWithoutMySQL:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
+        self.oc_api.import_is("imagestreams/perl-rhel.json", "", skip_check=True)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    def test_perl_template_inside_cluster(self):
+        service_name = "perl-testing"
+        template_url = self.oc_api.get_raw_url_for_json(
+            container="dancer-ex", dir="openshift/templates", filename="dancer.json", branch="master"
+        )
+        assert self.oc_api.deploy_template_with_image(
+            image_name=IMAGE_NAME,
+            template=template_url,
+            name_in_template="perl",
+            openshift_args=[
+                f"SOURCE_REPOSITORY_REF=master",
+                f"PERL_VERSION={VERSION}",
+                f"NAME={service_name}",
+                "SOURCE_REPOSITORY_REF=master"
+            ]
+        )
+        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template=service_name, expected_output="Welcome to your Dancer application on OpenShift"
+        )
+
+
+class TestDeployDancerExTemplateWithMySQL:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
+        self.oc_api.import_is("imagestreams/perl-rhel.json", "", skip_check=True)
+        assert self.oc_api.upload_image(DEPLOYED_MYSQL_IMAGE, f"{IMAGE_TAG}")
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    def test_perl_template_inside_cluster(self):
+        service_name = "perl-testing"
+        template_url = self.oc_api.get_raw_url_for_json(
+            container="dancer-ex", dir="openshift/templates", filename="dancer-mysql-persistent.json", branch="master"
+        )
+        assert self.oc_api.deploy_template_with_image(
+            image_name=IMAGE_NAME,
+            template=template_url,
+            name_in_template="perl",
+            openshift_args=[
+                f"SOURCE_REPOSITORY_REF=master",
+                f"PERL_VERSION={VERSION}",
+                f"NAME={service_name}",
+                f"MYSQL_VERSION={MYSQL_VERSION}"
+
+            ]
+        )
+        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template=service_name, expected_output="Welcome to your Dancer application on OpenShift"
+        )

--- a/test/test_deploy_templates.py
+++ b/test/test_deploy_templates.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+from container_ci_suite.openshift import OpenShiftAPI
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+
+
+class TestDeployTemplate:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
+        self.oc_api.import_is("imagestreams/perl-rhel.json", "", skip_check=True)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    def test_perl_template_inside_cluster(self):
+        service_name = "perl-testing"
+        assert self.oc_api.deploy_template_with_image(
+            image_name=IMAGE_NAME,
+            template=f"examples/templates/sample-test-app.json",
+            name_in_template="perl",
+            openshift_args=[
+                f"SOURCE_REPOSITORY_REF=master",
+                f"VERSION={VERSION}",
+                f"NAME={service_name}"
+            ]
+        )
+        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template=service_name, expected_output="Everything is OK"
+        )

--- a/test/test_imagestreams_quickstart.py
+++ b/test/test_imagestreams_quickstart.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+import pytest
+
+from container_ci_suite.openshift import OpenShiftAPI
+from container_ci_suite.utils import check_variables
+
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+
+VERSION = os.getenv("SINGLE_VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("OS")
+
+TAGS = {
+    "rhel7": "-ubi7",
+    "rhel8": "-ubi8",
+    "rhel9": "-ubi9"
+}
+
+TAG = TAGS.get(OS, None)
+
+
+# Replacement with 'test_python_s2i_templates'
+class TestImagestreamsQuickstart:
+
+    def setup_method(self):
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
+
+    def teardown_method(self):
+        self.oc_api.delete_project()
+
+    def test_perl_template_inside_cluster(self):
+        new_version = VERSION
+        if VERSION == "5.26-mod_fcgid":
+            new_version = "5.26"
+        service_name = "perl-testing"
+        assert self.oc_api.imagestream_quickstart(
+            imagestream_file="imagestreams/perl-rhel.json",
+            template_file="examples/templates/sample-test-app.json",
+            image_name=IMAGE_NAME,
+            name_in_template="perl",
+            openshift_args=[
+                f"SOURCE_REPOSITORY_REF=master",
+                f"VERSION={new_version}{TAG}",
+                f"NAME={service_name}"
+            ]
+        )
+        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.check_response_inside_cluster(
+            name_in_template=service_name, expected_output="Everything is OK"
+        )

--- a/test/test_latest_imagestreams.py
+++ b/test/test_latest_imagestreams.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+from pathlib import Path
+
+from container_ci_suite.imagestreams import ImageStreamChecker
+from container_ci_suite.utils import check_variables
+
+TEST_DIR = Path(os.path.abspath(os.path.dirname(__file__)))
+
+if not check_variables():
+    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
+    sys.exit(1)
+
+VERSION = os.getenv("SINGLE_VERSION")
+
+
+# Replacement with 'test_latest_imagestreams'
+class TestLatestImagestreams:
+
+    def setup_method(self):
+        self.isc = ImageStreamChecker(working_dir=TEST_DIR.parent.parent)
+
+    def test_latest_imagestream(self):
+        self.latest_version = self.isc.get_latest_version()
+        assert self.latest_version != ""
+        self.isc.check_imagestreams(self.latest_version)


### PR DESCRIPTION
This pull request supports testing perl container in OpenShift 4 by PyTest.

See a similar pull request here:
https://github.com/sclorg/s2i-python-container/pull/691

The pull request is separated into several commit in order to better review.
1) Adding test suite into `test` directory
2) Remove deprecated OpenShift 3 tests
3) Fix imagestream custom_tag definition
4) Distribution pytest into `<version>/test` symlinks.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
