### PR TITLE
Support enabling perl-container on RHEL10

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "5.26", "5.26-mod_fcgid", "5.30", "5.32", "5.34", "5.36", "5.38", "5.40" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s" ]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-pytests.yml
+++ b/.github/workflows/openshift-pytests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "5.26", "5.26-mod_fcgid", "5.30-mod_fcgid", "5.32" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-pytest" ]
 
     steps:

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "5.26", "5.26-mod_fcgid", "5.30", "5.32", "5.34", "5.36", "5.38" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-4" ]
 
     steps:


### PR DESCRIPTION
This pull request only enables testing perl container on RHEL10 host

No code is changed only GitHub Action itself




<!-- issue-commentator = {"comment-id":"2597692318"} -->















































<!-- testing-farm = {"lock":"false","comment-id":"2597713552","data":[{"id":"3b148da3-be2c-4460-9a0c-88ac00b11f2d","name":"CentOS Stream 10 - 5.40","status":"complete","outcome":"passed","runTime":737.152548,"created":"2025-01-17T08:30:30.218102","updated":"2025-01-17T08:30:30.218139","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3b148da3-be2c-4460-9a0c-88ac00b11f2d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3b148da3-be2c-4460-9a0c-88ac00b11f2d/pipeline.log\">pipeline</a>"]},{"id":"abd28234-a191-4b20-b3ee-515c068d8763","name":"CentOS Stream 9 - 5.32","status":"complete","outcome":"passed","runTime":761.269866,"created":"2025-01-17T08:30:16.686957","updated":"2025-01-17T08:30:16.686963","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/abd28234-a191-4b20-b3ee-515c068d8763\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/abd28234-a191-4b20-b3ee-515c068d8763/pipeline.log\">pipeline</a>"]},{"id":"9023a940-e2cd-4555-a019-f089d7b3a3d0","name":"Fedora - 5.40","status":"complete","outcome":"passed","runTime":1050.849152,"created":"2025-01-17T08:30:31.411063","updated":"2025-01-17T08:30:31.411071","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9023a940-e2cd-4555-a019-f089d7b3a3d0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9023a940-e2cd-4555-a019-f089d7b3a3d0/pipeline.log\">pipeline</a>"]},{"id":"585d68a9-7322-4748-a2ae-0884261f22e2","name":"Fedora - 5.36","status":"complete","outcome":"passed","runTime":1063.361325,"created":"2025-01-17T08:30:25.099908","updated":"2025-01-17T08:30:25.099917","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/585d68a9-7322-4748-a2ae-0884261f22e2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/585d68a9-7322-4748-a2ae-0884261f22e2/pipeline.log\">pipeline</a>"]},{"id":"1bb483e5-3952-4b43-8550-408091335ca9","name":"Fedora - 5.38","status":"complete","outcome":"passed","runTime":1121.41027,"created":"2025-01-17T08:30:31.297744","updated":"2025-01-17T08:30:31.297755","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1bb483e5-3952-4b43-8550-408091335ca9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1bb483e5-3952-4b43-8550-408091335ca9/pipeline.log\">pipeline</a>"]},{"id":"b5177909-8a64-4ef6-b0ab-a2e50403e5ee","name":"RHEL9 - 5.32","status":"complete","outcome":"passed","runTime":1351.792032,"created":"2025-01-17T08:30:20.120285","updated":"2025-01-17T08:30:20.120293","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5177909-8a64-4ef6-b0ab-a2e50403e5ee\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5177909-8a64-4ef6-b0ab-a2e50403e5ee/pipeline.log\">pipeline</a>"]},{"id":"6173afdc-29d0-42a9-b485-cb7b43d41590","name":"RHEL8 - 5.32","status":"complete","outcome":"passed","runTime":1464.85549,"created":"2025-01-17T08:30:17.664375","updated":"2025-01-17T08:30:17.664384","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6173afdc-29d0-42a9-b485-cb7b43d41590\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6173afdc-29d0-42a9-b485-cb7b43d41590/pipeline.log\">pipeline</a>"]},{"id":"a8f7224d-96af-40fe-b7f3-c34dcb1d91dd","name":"RHEL8 - 5.26-mod_fcgid","runTime":1520.433957,"created":"2025-01-17T08:30:08.488477","updated":"2025-01-17T08:30:08.488492","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8f7224d-96af-40fe-b7f3-c34dcb1d91dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8f7224d-96af-40fe-b7f3-c34dcb1d91dd/pipeline.log\">pipeline</a>"]}]} -->