### PR TITLE
Helm charts were renamed to 'redhat-' prefix

### DIFF
--- a/test/test_dancer_ex_standalone.py
+++ b/test/test_dancer_ex_standalone.py
@@ -28,7 +28,7 @@ class TestPerlDancerExTemplate:
     def test_dancer_ex_template_inside_cluster(self):
         service_name = "perl-testing"
         assert self.oc_api.deploy_s2i_app(
-            image_name=IMAGE_NAME, app=f"https://github.com/sclorg/dancer-ex.git",
+            image_name=IMAGE_NAME, app="https://github.com/sclorg/dancer-ex.git",
             context=".",
             service_name=service_name
         )

--- a/test/test_dancer_ex_templates.py
+++ b/test/test_dancer_ex_templates.py
@@ -44,7 +44,6 @@ class TestDeployDancerExTemplateWithoutMySQL:
             template=template_url,
             name_in_template="perl",
             openshift_args=[
-                f"SOURCE_REPOSITORY_REF=master",
                 f"PERL_VERSION={VERSION}",
                 f"NAME={service_name}",
                 "SOURCE_REPOSITORY_REF=master"

--- a/test/test_helm_dancer_app.py
+++ b/test/test_helm_dancer_app.py
@@ -59,7 +59,7 @@ class TestHelmPerlDancerAppTemplate:
                 "namespace": self.hc_api.namespace
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example")
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=400)
         assert self.hc_api.test_helm_curl_output(
             route_name="dancer-example",
             expected_str="Welcome to your Dancer application"
@@ -77,5 +77,5 @@ class TestHelmPerlDancerAppTemplate:
                 "namespace": self.hc_api.namespace
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example")
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=400)
         assert self.hc_api.test_helm_chart(expected_str=["Welcome to your Dancer application"])

--- a/test/test_helm_dancer_app.py
+++ b/test/test_helm_dancer_app.py
@@ -34,7 +34,7 @@ TAG = TAGS.get(OS, None)
 class TestHelmPerlDancerAppTemplate:
 
     def setup_method(self):
-        package_name = "perl-dancer-application"
+        package_name = "redhat-perl-dancer-application"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(
@@ -48,10 +48,10 @@ class TestHelmPerlDancerAppTemplate:
     def test_dancer_application_curl_output(self):
         if self.hc_api.oc_api.shared_cluster:
             pytest.skip("Do NOT test on shared cluster")
-        self.hc_api.package_name = "perl-imagestreams"
+        self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "perl-dancer-application"
+        self.hc_api.package_name = "redhat-perl-dancer-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
@@ -66,10 +66,10 @@ class TestHelmPerlDancerAppTemplate:
         )
 
     def test_dancer_application_helm_test(self):
-        self.hc_api.package_name = "perl-imagestreams"
+        self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "perl-dancer-application"
+        self.hc_api.package_name = "redhat-perl-dancer-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={

--- a/test/test_helm_dancer_app.py
+++ b/test/test_helm_dancer_app.py
@@ -36,7 +36,7 @@ class TestHelmPerlDancerAppTemplate:
     def setup_method(self):
         package_name = "redhat-perl-dancer-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_helm_dancer_app.py
+++ b/test/test_helm_dancer_app.py
@@ -60,9 +60,9 @@ class TestHelmPerlDancerAppTemplate:
             }
         )
         assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=400)
-        assert self.hc_api.test_helm_curl_output(
-            route_name="dancer-example",
-            expected_str="Welcome to your Dancer application"
+        assert self.hc_api.oc_api.check_response_inside_cluster(
+            name_in_template="dancer-example",
+            expected_output="Welcome to your Dancer application"
         )
 
     def test_dancer_application_helm_test(self):

--- a/test/test_helm_dancer_mysql_template.py
+++ b/test/test_helm_dancer_mysql_template.py
@@ -14,13 +14,28 @@ if not check_variables():
 
 test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 
+VERSION = os.getenv("VERSION")
+IMAGE_NAME = os.getenv("IMAGE_NAME")
+OS = os.getenv("TARGET")
+
+if VERSION == "5.30-mod_fcgid":
+    VERSION = "5.30"
+
+if VERSION == "5.26-mod_fcgid":
+    VERSION = "5.26"
+
+TAGS = {
+    "rhel8": "-ubi8",
+    "rhel9": "-ubi9"
+}
+TAG = TAGS.get(OS, None)
 
 class TestHelmPerlDancerMysqlAppTemplate:
 
     def setup_method(self):
         package_name = "redhat-perl-dancer-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -39,7 +54,7 @@ class TestHelmPerlDancerMysqlAppTemplate:
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
-                "perl_version": "5.32-ubi8",
+                "perl_version": f"{VERSION}{TAG}",
                 "namespace": self.hc_api.namespace
             }
         )
@@ -58,7 +73,7 @@ class TestHelmPerlDancerMysqlAppTemplate:
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
-                "perl_version": "5.32-ubi8",
+                "perl_version": f"{VERSION}{TAG}",
                 "namespace": self.hc_api.namespace
             }
         )

--- a/test/test_helm_dancer_mysql_template.py
+++ b/test/test_helm_dancer_mysql_template.py
@@ -59,9 +59,9 @@ class TestHelmPerlDancerMysqlAppTemplate:
             }
         )
         assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=400)
-        assert self.hc_api.test_helm_curl_output(
-            route_name="dancer-example",
-            expected_str="Welcome to your Dancer application"
+        assert self.hc_api.oc_api.check_response_inside_cluster(
+            name_in_template="dancer-example",
+            expected_output="Welcome to your Dancer application"
         )
 
 

--- a/test/test_helm_dancer_mysql_template.py
+++ b/test/test_helm_dancer_mysql_template.py
@@ -43,7 +43,7 @@ class TestHelmPerlDancerMysqlAppTemplate:
                 "namespace": self.hc_api.namespace
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example")
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=400)
         assert self.hc_api.test_helm_curl_output(
             route_name="dancer-example",
             expected_str="Welcome to your Dancer application"
@@ -62,5 +62,5 @@ class TestHelmPerlDancerMysqlAppTemplate:
                 "namespace": self.hc_api.namespace
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example")
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=400)
         assert self.hc_api.test_helm_chart(expected_str=["Welcome to your Dancer application"])

--- a/test/test_helm_dancer_mysql_template.py
+++ b/test/test_helm_dancer_mysql_template.py
@@ -18,7 +18,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmPerlDancerMysqlAppTemplate:
 
     def setup_method(self):
-        package_name = "perl-dancer-application"
+        package_name = "redhat-perl-dancer-application"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(
@@ -32,10 +32,10 @@ class TestHelmPerlDancerMysqlAppTemplate:
     def test_dancer_application(self):
         if self.hc_api.oc_api.shared_cluster:
             pytest.skip("Do NOT test on shared cluster")
-        self.hc_api.package_name = "perl-imagestreams"
+        self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "perl-dancer-application"
+        self.hc_api.package_name = "redhat-perl-dancer-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
@@ -51,10 +51,10 @@ class TestHelmPerlDancerMysqlAppTemplate:
 
 
     def test_dancer_application_helm_test(self):
-        self.hc_api.package_name = "perl-imagestreams"
+        self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "perl-dancer-application"
+        self.hc_api.package_name = "redhat-perl-dancer-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={

--- a/test/test_helm_perl_imagestreams.py
+++ b/test/test_helm_perl_imagestreams.py
@@ -20,7 +20,7 @@ class TestHelmRHELPerlImageStreams:
     def setup_method(self):
         package_name = "redhat-perl-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_helm_perl_imagestreams.py
+++ b/test/test_helm_perl_imagestreams.py
@@ -18,7 +18,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELPerlImageStreams:
 
     def setup_method(self):
-        package_name = "perl-imagestreams"
+        package_name = "redhat-perl-imagestreams"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(


### PR DESCRIPTION


<!-- issue-commentator = {"comment-id":"2647932350"} -->



















































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2647934382","data":[{"id":"3a7e5af7-7b8f-45f3-b33e-8435eb47f7fa","name":"RHEL10 - OpenShift 4 - 5.40","status":"complete","outcome":"passed","runTime":1269.421365,"created":"2025-02-18T13:03:44.798157","updated":"2025-02-18T13:03:44.798165","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a7e5af7-7b8f-45f3-b33e-8435eb47f7fa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a7e5af7-7b8f-45f3-b33e-8435eb47f7fa/pipeline.log\">pipeline</a>"]},{"id":"8230592a-779c-4c5b-86b6-91f1cc3d52b8","name":"RHEL10 - PyTest - OpenShift 4 - 5.40","status":"complete","outcome":"error","runTime":1983.483783,"created":"2025-02-18T13:03:50.026801","updated":"2025-02-18T13:03:50.026810","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8230592a-779c-4c5b-86b6-91f1cc3d52b8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8230592a-779c-4c5b-86b6-91f1cc3d52b8/pipeline.log\">pipeline</a>"]},{"id":"df2c57e1-5883-4047-96f7-45797666b1de","name":"RHEL9 - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":1254.819007,"created":"2025-02-18T13:03:35.877343","updated":"2025-02-18T13:03:35.877351","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/df2c57e1-5883-4047-96f7-45797666b1de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/df2c57e1-5883-4047-96f7-45797666b1de/pipeline.log\">pipeline</a>"]},{"id":"10e5f826-684d-4e7e-8373-fd86be4db930","name":"RHEL8 - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":1495.472428,"created":"2025-02-18T13:03:35.858715","updated":"2025-02-18T13:03:35.858721","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/10e5f826-684d-4e7e-8373-fd86be4db930\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/10e5f826-684d-4e7e-8373-fd86be4db930/pipeline.log\">pipeline</a>"]},{"id":"cd6a62ad-5f09-455a-b082-996b743ec1aa","name":"RHEL8 - PyTest - OpenShift 4 - 5.26-mod_fcgid","runTime":1862.137434,"created":"2025-02-18T14:42:21.868729","updated":"2025-02-18T14:42:21.868735","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd6a62ad-5f09-455a-b082-996b743ec1aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd6a62ad-5f09-455a-b082-996b743ec1aa/pipeline.log\">pipeline</a>"]},{"id":"508369cd-909b-4e9e-a1e5-08fe0893dc79","name":"RHEL9 - PyTest - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":2300.909802,"created":"2025-02-18T13:03:49.793866","updated":"2025-02-18T13:03:49.793873","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/508369cd-909b-4e9e-a1e5-08fe0893dc79\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/508369cd-909b-4e9e-a1e5-08fe0893dc79/pipeline.log\">pipeline</a>"]},{"id":"454035f6-e5a4-4865-bad1-8ce87cb2314b","name":"RHEL8 - PyTest - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":2671.877888,"created":"2025-02-18T13:03:48.920399","updated":"2025-02-18T13:03:48.920406","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/454035f6-e5a4-4865-bad1-8ce87cb2314b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/454035f6-e5a4-4865-bad1-8ce87cb2314b/pipeline.log\">pipeline</a>"]},{"id":"b336e89d-0044-4f48-86cf-e98726107b48","name":"RHEL8 - OpenShift 4 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1473.370445,"created":"2025-02-18T13:03:37.486267","updated":"2025-02-18T13:03:37.486275","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b336e89d-0044-4f48-86cf-e98726107b48\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b336e89d-0044-4f48-86cf-e98726107b48/pipeline.log\">pipeline</a>"]}]} -->