### PR TITLE
Fixing OpenShift Pytest test suite

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -32,7 +32,7 @@ ct_os_check_login || exit $OC_ERR
 
 ct_os_tag_image_for_cvp "perl"
 
-set -u
+set -ux
 
 # For testing on OpenShift 4 we use internal registry
 export CT_OCP4_TEST=true

--- a/test/test-lib-perl.sh
+++ b/test/test-lib-perl.sh
@@ -19,6 +19,10 @@ function test_perl_imagestream() {
   if [ "${VERSION}" == "5.26-mod_fcgid" ]; then
     VERSION="5.26"
   fi
+  if [ "${OS}" == "rhel10" ]; then
+    echo "Skip testing imagestreams on RHEL10 till they are not available."
+    return
+  fi
   echo "Testing perl imagestream application"
   ct_os_test_image_stream_quickstart "${THISDIR}/imagestreams/perl-${OS%[0-9]*}.json" \
                                      "${THISDIR}/sample-test-app.json" \

--- a/test/test_dancer_ex_standalone.py
+++ b/test/test_dancer_ex_standalone.py
@@ -15,24 +15,30 @@ VERSION = os.getenv("VERSION")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 
+if VERSION == "5.30-mod_fcgid":
+    VERSION = "5.30"
+
+if VERSION == "5.26-mod_fcgid":
+    VERSION = "5.26"
 
 # Replacement with 'test_python_s2i_app_ex'
 class TestPerlDancerExTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_dancer_ex_template_inside_cluster(self):
-        service_name = "perl-testing"
+        new_version = VERSION.replace(".", "")
+        service_name = f"perl-{new_version}-testing"
         assert self.oc_api.deploy_s2i_app(
             image_name=IMAGE_NAME, app="https://github.com/sclorg/dancer-ex.git",
             context=".",
             service_name=service_name
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name, timeout=480)
+        assert self.oc_api.is_s2i_pod_running(pod_name_prefix=service_name, cycle_count=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Welcome to your Dancer application on OpenShift"
         )

--- a/test/test_dancer_ex_standalone.py
+++ b/test/test_dancer_ex_standalone.py
@@ -20,7 +20,7 @@ OS = os.getenv("TARGET")
 class TestPerlDancerExTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -32,7 +32,7 @@ class TestPerlDancerExTemplate:
             context=".",
             service_name=service_name
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Welcome to your Dancer application on OpenShift"
         )

--- a/test/test_dancer_ex_templates.py
+++ b/test/test_dancer_ex_templates.py
@@ -14,6 +14,12 @@ VERSION = os.getenv("VERSION")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 
+if VERSION == "5.30-mod_fcgid":
+    VERSION = "5.30"
+
+if VERSION == "5.26-mod_fcgid":
+    VERSION = "5.26"
+
 DEPLOYED_MYSQL_IMAGE = "quay.io/sclorg/mysql-80-c9s:c9s"
 
 MYSQL_TAGS = {
@@ -49,7 +55,7 @@ class TestDeployDancerExTemplateWithoutMySQL:
                 "SOURCE_REPOSITORY_REF=master"
             ]
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Welcome to your Dancer application on OpenShift"
         )
@@ -82,7 +88,7 @@ class TestDeployDancerExTemplateWithMySQL:
 
             ]
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Welcome to your Dancer application on OpenShift"
         )

--- a/test/test_dancer_ex_templates.py
+++ b/test/test_dancer_ex_templates.py
@@ -24,7 +24,8 @@ DEPLOYED_MYSQL_IMAGE = "quay.io/sclorg/mysql-80-c9s:c9s"
 
 MYSQL_TAGS = {
     "rhel8": "-el8",
-    "rhel9": "-el9"
+    "rhel9": "-el9",
+    "rhel10": "-el10",
 }
 MYSQL_TAG = MYSQL_TAGS.get(OS, None)
 IMAGE_TAG = f"mysql:8.0{MYSQL_TAG}"

--- a/test/test_deploy_templates.py
+++ b/test/test_deploy_templates.py
@@ -13,6 +13,12 @@ VERSION = os.getenv("VERSION")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 
+if VERSION == "5.30-mod_fcgid":
+    VERSION = "5.30"
+
+if VERSION == "5.26-mod_fcgid":
+    VERSION = "5.26"
+
 
 class TestDeployTemplate:
 
@@ -35,7 +41,7 @@ class TestDeployTemplate:
                 f"NAME={service_name}"
             ]
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Everything is OK"
         )

--- a/test/test_deploy_templates.py
+++ b/test/test_deploy_templates.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import pytest
+
 from container_ci_suite.openshift import OpenShiftAPI
 from container_ci_suite.utils import check_variables
 
@@ -30,6 +32,8 @@ class TestDeployTemplate:
         self.oc_api.delete_project()
 
     def test_perl_template_inside_cluster(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         service_name = "perl-testing"
         assert self.oc_api.deploy_template_with_image(
             image_name=IMAGE_NAME,
@@ -41,7 +45,7 @@ class TestDeployTemplate:
                 f"NAME={service_name}"
             ]
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name, timeout=480)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Everything is OK"
         )

--- a/test/test_helm_dancer_app.py
+++ b/test/test_helm_dancer_app.py
@@ -37,7 +37,7 @@ class TestHelmPerlDancerAppTemplate:
     def setup_method(self):
         package_name = "redhat-perl-dancer-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -49,6 +49,8 @@ class TestHelmPerlDancerAppTemplate:
     def test_dancer_application_curl_output(self):
         if self.hc_api.oc_api.shared_cluster:
             pytest.skip("Do NOT test on shared cluster")
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
@@ -67,6 +69,8 @@ class TestHelmPerlDancerAppTemplate:
         )
 
     def test_dancer_application_helm_test(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/test/test_helm_dancer_app.py
+++ b/test/test_helm_dancer_app.py
@@ -26,7 +26,8 @@ if VERSION == "5.26-mod_fcgid":
 
 TAGS = {
     "rhel8": "-ubi8",
-    "rhel9": "-ubi9"
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10",
 }
 TAG = TAGS.get(OS, None)
 

--- a/test/test_helm_dancer_app.py
+++ b/test/test_helm_dancer_app.py
@@ -36,7 +36,7 @@ class TestHelmPerlDancerAppTemplate:
     def setup_method(self):
         package_name = "redhat-perl-dancer-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_helm_dancer_mysql_template.py
+++ b/test/test_helm_dancer_mysql_template.py
@@ -26,7 +26,8 @@ if VERSION == "5.26-mod_fcgid":
 
 TAGS = {
     "rhel8": "-ubi8",
-    "rhel9": "-ubi9"
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10",
 }
 TAG = TAGS.get(OS, None)
 

--- a/test/test_helm_dancer_mysql_template.py
+++ b/test/test_helm_dancer_mysql_template.py
@@ -35,7 +35,7 @@ class TestHelmPerlDancerMysqlAppTemplate:
     def setup_method(self):
         package_name = "redhat-perl-dancer-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -58,7 +58,7 @@ class TestHelmPerlDancerMysqlAppTemplate:
                 "namespace": self.hc_api.namespace
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=400)
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=480)
         assert self.hc_api.oc_api.check_response_inside_cluster(
             name_in_template="dancer-example",
             expected_output="Welcome to your Dancer application"
@@ -77,5 +77,5 @@ class TestHelmPerlDancerMysqlAppTemplate:
                 "namespace": self.hc_api.namespace
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=400)
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="dancer-example", timeout=480)
         assert self.hc_api.test_helm_chart(expected_str=["Welcome to your Dancer application"])

--- a/test/test_helm_dancer_mysql_template.py
+++ b/test/test_helm_dancer_mysql_template.py
@@ -36,7 +36,7 @@ class TestHelmPerlDancerMysqlAppTemplate:
     def setup_method(self):
         package_name = "redhat-perl-dancer-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -48,6 +48,8 @@ class TestHelmPerlDancerMysqlAppTemplate:
     def test_dancer_application(self):
         if self.hc_api.oc_api.shared_cluster:
             pytest.skip("Do NOT test on shared cluster")
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
@@ -67,6 +69,8 @@ class TestHelmPerlDancerMysqlAppTemplate:
 
 
     def test_dancer_application_helm_test(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/test/test_helm_perl_imagestreams.py
+++ b/test/test_helm_perl_imagestreams.py
@@ -20,7 +20,7 @@ class TestHelmRHELPerlImageStreams:
     def setup_method(self):
         package_name = "redhat-perl-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_imagestreams_quickstart.py
+++ b/test/test_imagestreams_quickstart.py
@@ -17,9 +17,9 @@ IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("OS")
 
 TAGS = {
-    "rhel7": "-ubi7",
     "rhel8": "-ubi8",
-    "rhel9": "-ubi9"
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10"
 }
 
 TAG = TAGS.get(OS, None)

--- a/test/test_imagestreams_quickstart.py
+++ b/test/test_imagestreams_quickstart.py
@@ -24,20 +24,23 @@ TAGS = {
 
 TAG = TAGS.get(OS, None)
 
+if VERSION == "5.30-mod_fcgid":
+    VERSION = "5.30"
+
+if VERSION == "5.26-mod_fcgid":
+    VERSION = "5.26"
+
 
 # Replacement with 'test_python_s2i_templates'
 class TestImagestreamsQuickstart:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_perl_template_inside_cluster(self):
-        new_version = VERSION
-        if VERSION == "5.26-mod_fcgid":
-            new_version = "5.26"
         service_name = "perl-testing"
         assert self.oc_api.imagestream_quickstart(
             imagestream_file="imagestreams/perl-rhel.json",
@@ -46,11 +49,11 @@ class TestImagestreamsQuickstart:
             name_in_template="perl",
             openshift_args=[
                 f"SOURCE_REPOSITORY_REF=master",
-                f"VERSION={new_version}{TAG}",
+                f"VERSION={VERSION}{TAG}",
                 f"NAME={service_name}"
             ]
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Everything is OK"
         )

--- a/test/test_imagestreams_quickstart.py
+++ b/test/test_imagestreams_quickstart.py
@@ -35,12 +35,14 @@ if VERSION == "5.26-mod_fcgid":
 class TestImagestreamsQuickstart:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="perl-testing", version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_perl_template_inside_cluster(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         service_name = "perl-testing"
         assert self.oc_api.imagestream_quickstart(
             imagestream_file="imagestreams/perl-rhel.json",
@@ -53,7 +55,7 @@ class TestImagestreamsQuickstart:
                 f"NAME={service_name}"
             ]
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name, timeout=480)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Everything is OK"
         )


### PR DESCRIPTION
This pull request fixes OpenShift tests.

The tests are now performed on Shared Cluster

<!-- issue-commentator = {"comment-id":"2703341419"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2703378485","data":[{"id":"690ff584-094d-4626-b85c-076c91eac55a","name":"CentOS Stream 9 - 5.32","status":"complete","outcome":"error","runTime":764.298826,"created":"2025-03-06T12:33:02.828271","updated":"2025-03-06T12:33:02.828278","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/690ff584-094d-4626-b85c-076c91eac55a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/690ff584-094d-4626-b85c-076c91eac55a/pipeline.log\">pipeline</a>"]},{"id":"79acbc43-8105-4d84-ad5b-ae6c7062f842","name":"Fedora - 5.36","status":"complete","outcome":"passed","runTime":990.538128,"created":"2025-03-06T12:33:15.154608","updated":"2025-03-06T12:33:15.154615","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/79acbc43-8105-4d84-ad5b-ae6c7062f842\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/79acbc43-8105-4d84-ad5b-ae6c7062f842/pipeline.log\">pipeline</a>"]},{"id":"f1b6fd25-4d56-4372-9b95-86c9dc7f1271","name":"Fedora - 5.40","status":"complete","outcome":"passed","runTime":789.541549,"created":"2025-03-06T12:33:21.457198","updated":"2025-03-06T12:33:21.457207","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f1b6fd25-4d56-4372-9b95-86c9dc7f1271\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f1b6fd25-4d56-4372-9b95-86c9dc7f1271/pipeline.log\">pipeline</a>"]},{"id":"d1424e5d-06d6-495f-b8fa-caf3c33ca388","name":"Fedora - 5.38","status":"complete","outcome":"passed","runTime":848.498549,"created":"2025-03-06T12:33:19.766262","updated":"2025-03-06T12:33:19.766270","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d1424e5d-06d6-495f-b8fa-caf3c33ca388\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d1424e5d-06d6-495f-b8fa-caf3c33ca388/pipeline.log\">pipeline</a>"]},{"id":"cbfb5fe8-30d1-4981-9104-2200b813b181","name":"CentOS Stream 10 - 5.40","status":"complete","outcome":"passed","runTime":867.780079,"created":"2025-03-06T12:33:20.898356","updated":"2025-03-06T12:33:20.898363","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cbfb5fe8-30d1-4981-9104-2200b813b181\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cbfb5fe8-30d1-4981-9104-2200b813b181/pipeline.log\">pipeline</a>"]},{"id":"7790b8dd-f145-46c6-b71e-d61914541808","name":"RHEL10 - PyTest - OpenShift 4 - 5.40","status":"complete","outcome":"passed","runTime":1222.326681,"created":"2025-04-28T08:38:45.040759","updated":"2025-04-28T08:38:45.040766","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7790b8dd-f145-46c6-b71e-d61914541808\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7790b8dd-f145-46c6-b71e-d61914541808/pipeline.log\">pipeline</a>"]},{"id":"ef3406e0-4d11-4fe8-9902-16a5126edd87","name":"RHEL9 - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":1497.422536,"created":"2025-04-28T07:37:13.774502","updated":"2025-04-28T07:37:13.774509","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ef3406e0-4d11-4fe8-9902-16a5126edd87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ef3406e0-4d11-4fe8-9902-16a5126edd87/pipeline.log\">pipeline</a>"]},{"id":"28935af5-e248-4bbd-977d-eed03f54c861","name":"RHEL10 - OpenShift 4 - 5.40","status":"complete","outcome":"passed","runTime":1131.173322,"created":"2025-04-28T08:38:38.296841","updated":"2025-04-28T08:38:38.296847","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/28935af5-e248-4bbd-977d-eed03f54c861\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/28935af5-e248-4bbd-977d-eed03f54c861/pipeline.log\">pipeline</a>"]},{"id":"0f8573f5-e113-41c6-990e-3c60f112b23c","name":"RHEL9 - 5.32","status":"complete","outcome":"passed","runTime":1249.91369,"created":"2025-03-06T12:33:09.984709","updated":"2025-03-06T12:33:09.984716","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0f8573f5-e113-41c6-990e-3c60f112b23c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0f8573f5-e113-41c6-990e-3c60f112b23c/pipeline.log\">pipeline</a>"]},{"id":"e8545ad9-c7f1-41a4-bc1f-6db3c72f6623","name":"RHEL10 - 5.40","status":"complete","outcome":"passed","runTime":1311.774214,"created":"2025-03-06T12:33:23.954449","updated":"2025-03-06T12:33:23.954456","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8545ad9-c7f1-41a4-bc1f-6db3c72f6623\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8545ad9-c7f1-41a4-bc1f-6db3c72f6623/pipeline.log\">pipeline</a>"]},{"id":"5d3873a6-daff-4731-8fe6-09e941d28c37","name":"RHEL8 - PyTest - OpenShift 4 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1720.662125,"created":"2025-04-28T08:38:46.019739","updated":"2025-04-28T08:38:46.019744","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d3873a6-daff-4731-8fe6-09e941d28c37\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d3873a6-daff-4731-8fe6-09e941d28c37/pipeline.log\">pipeline</a>"]},{"id":"b1d2d49d-3099-4217-9304-c2473d764b52","name":"RHEL8 - OpenShift 4 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1627.14447,"created":"2025-04-28T07:37:06.811590","updated":"2025-04-28T07:37:06.811596","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b1d2d49d-3099-4217-9304-c2473d764b52\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b1d2d49d-3099-4217-9304-c2473d764b52/pipeline.log\">pipeline</a>"]},{"id":"bd63d460-8739-452c-919d-1eff56d4133a","name":"RHEL8 - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":1363.496266,"created":"2025-04-28T07:40:01.788091","updated":"2025-04-28T07:40:01.788096","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bd63d460-8739-452c-919d-1eff56d4133a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bd63d460-8739-452c-919d-1eff56d4133a/pipeline.log\">pipeline</a>"]},{"id":"0dc6211f-901e-4694-ac00-023c5f029314","name":"RHEL8 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1525.37373,"created":"2025-03-06T12:32:58.182977","updated":"2025-03-06T12:32:58.182985","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0dc6211f-901e-4694-ac00-023c5f029314\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0dc6211f-901e-4694-ac00-023c5f029314/pipeline.log\">pipeline</a>"]},{"id":"99b8c228-3bfc-4f44-a43f-f8da72cfe0b8","name":"RHEL8 - 5.32","status":"complete","outcome":"passed","runTime":1468.646422,"created":"2025-03-06T12:33:07.190463","updated":"2025-03-06T12:33:07.190471","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/99b8c228-3bfc-4f44-a43f-f8da72cfe0b8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/99b8c228-3bfc-4f44-a43f-f8da72cfe0b8/pipeline.log\">pipeline</a>"]},{"id":"8e554c57-a2be-413d-9716-32b675a0f703","name":"RHEL9 - PyTest - OpenShift 4 - 5.32","runTime":2519.826694,"created":"2025-04-28T08:38:48.492266","updated":"2025-04-28T08:38:48.492273","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e554c57-a2be-413d-9716-32b675a0f703\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e554c57-a2be-413d-9716-32b675a0f703/pipeline.log\">pipeline</a>"]},{"id":"c28dc5de-d408-4e5e-a9f3-cb413052b7c8","name":"RHEL8 - PyTest - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":2700.760084,"created":"2025-04-28T07:23:52.708344","updated":"2025-04-28T07:23:52.708352","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c28dc5de-d408-4e5e-a9f3-cb413052b7c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c28dc5de-d408-4e5e-a9f3-cb413052b7c8/pipeline.log\">pipeline</a>"]}]} -->