### PR TITLE
Fix typo in github actrion. Missing brackets

### DIFF
--- a/.github/workflows/auto-merge-on-demand.yml
+++ b/.github/workflows/auto-merge-on-demand.yml
@@ -19,7 +19,7 @@ jobs:
     if: |
       github.repository_owner == 'sclorg'
       || (contains(github.event.comment.body, '/auto-merge')
-      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
 
     outputs:


### PR DESCRIPTION


<!-- issue-commentator = {"comment-id":"2915381589"} -->