### PR TITLE
Deprecate version 5.32 for rhel8

### DIFF
--- a/5.32/README.md
+++ b/5.32/README.md
@@ -28,7 +28,7 @@ version, that is included in the image; those versions can be changed anytime.
 Usage in Openshift
 ------------------
 
-In this example, we will assume that you are using the `ubi8/perl-532` image, available via `perl:5.32` imagestream tag in Openshift.
+In this example, we will assume that you are using the `ubi9/perl-532` image, available via `perl:5.32` imagestream tag in Openshift.
 To build a simple [perl-sample-app](https://github.com/sclorg/dancer-ex.git) application in Openshift:
 
 ```
@@ -69,10 +69,10 @@ To use the Perl image in a Dockerfile, follow these steps:
 #### 1. Pull a base builder image to build on
 
 ```
-podman pull ubi8/perl-532
+podman pull ubi9/perl-532
 ```
 
-An ubi8 image `ubi8/perl-532` is used in this example.
+An ubi9 image `ubi9/perl-532` is used in this example.
 
 #### 2. Pull and application code
 
@@ -95,7 +95,7 @@ For all these three parts, users can either setup all manually and use commands 
 ##### 3.1 To use your own setup, create a Dockerfile with this content:
 
 ```
-FROM ubi8/perl-532
+FROM ubi9/perl-532
 
 # Add application sources
 ADD app-src .
@@ -132,7 +132,7 @@ CMD exec httpd -C 'Include /opt/app-root/etc/httpd.conf' -D FOREGROUND
 ##### 3.2 To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
 
 ```
-FROM ubi8/perl-532
+FROM ubi9/perl-532
 
 # Add application sources to a directory that the assemble scriptexpects them
 # and set permissions so that the container runs without root access

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ To build a Perl image, choose either the CentOS Stream or RHEL based image:
 
 *  **RHEL based image**
 
-    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhel8/perl-532).
+    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhel9/perl-532).
     To download it run:
 
     ```
-    $ podman pull registry.access.redhat.com/rhel8/perl-532
+    $ podman pull registry.access.redhat.com/rhel9/perl-532
     ```
 
     To build a RHEL based Perl image, you need to run the build on a properly
@@ -67,7 +67,7 @@ To build a Perl image, choose either the CentOS Stream or RHEL based image:
     ```
     $ git clone --recursive https://github.com/sclorg/s2i-perl-container.git
     $ cd s2i-perl-container
-    $ make build TARGET=rhel8 VERSIONS=5.32
+    $ make build TARGET=rhel9 VERSIONS=5.32
     ```
 
 *  **CentOS Stream based image**
@@ -122,12 +122,12 @@ Users can choose between testing a Perl test application based on a RHEL or Cent
 
 *  **RHEL based image**
 
-    To test a RHEL8-based image, you need to run the test on a properly
+    To test a RHEL9-based image, you need to run the test on a properly
     subscribed RHEL machine.
 
     ```
     $ cd s2i-perl-container
-    $ make test TARGET=rhel8 VERSIONS=5.32
+    $ make test TARGET=rhel9 VERSIONS=5.32
     ```
 
 *  **CentOS Stream based image**

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -12,7 +12,7 @@
     latest: "5.32-ubi9"
     distros:
       - name: UBI 8
-        app_versions: ["5.26", "5.32"]
+        app_versions: ["5.26"]
 
       - name: UBI 9
         app_versions: ["5.32"]
@@ -24,7 +24,7 @@
     latest: "5.32-ubi9"
     distros:
       - name: UBI 8
-        app_versions: ["5.26", "5.32"]
+        app_versions: ["5.26"]
 
       - name: UBI 9
         app_versions: ["5.32"]
@@ -36,7 +36,7 @@
     latest: "5.32-ubi9"
     distros:
       - name: UBI 8
-        app_versions: ["5.26", "5.32"]
+        app_versions: ["5.26"]
 
       - name: UBI 9
         app_versions: ["5.32"]

--- a/imagestreams/perl-centos.json
+++ b/imagestreams/perl-centos.json
@@ -29,25 +29,6 @@
         }
       },
       {
-        "name": "5.32-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.32 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
-          "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "version": "5.32",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/perl-532:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "5.32-ubi9",
         "annotations": {
           "openshift.io/display-name": "Perl 5.32 (UBI 9)",

--- a/imagestreams/perl-rhel-aarch64.json
+++ b/imagestreams/perl-rhel-aarch64.json
@@ -29,25 +29,6 @@
         }
       },
       {
-        "name": "5.32-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.32 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
-          "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "version": "5.32",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/perl-532:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "5.32-ubi9",
         "annotations": {
           "openshift.io/display-name": "Perl 5.32 (UBI 9)",

--- a/imagestreams/perl-rhel.json
+++ b/imagestreams/perl-rhel.json
@@ -29,25 +29,6 @@
         }
       },
       {
-        "name": "5.32-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Perl 5.32 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
-          "iconClass": "icon-perl",
-          "tags": "builder,perl",
-          "version": "5.32",
-          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/perl-532:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "5.32-ubi9",
         "annotations": {
           "openshift.io/display-name": "Perl 5.32 (UBI 9)",

--- a/test/test_helm_dancer_mysql_template.py
+++ b/test/test_helm_dancer_mysql_template.py
@@ -31,6 +31,9 @@ TAGS = {
 }
 TAG = TAGS.get(OS, None)
 
+if VERSION == "5.32" and OS == "rhel8":
+    pytest.skip("This version is not being tested as it is deprecated")
+
 class TestHelmPerlDancerMysqlAppTemplate:
 
     def setup_method(self):

--- a/test/test_helm_perl_imagestreams.py
+++ b/test/test_helm_perl_imagestreams.py
@@ -30,15 +30,15 @@ class TestHelmRHELPerlImageStreams:
         self.hc_api.delete_project()
 
     @pytest.mark.parametrize(
-        "version,registry",
+        "version,registry,expected",
         [
-            ("5.40-ubi10", "registry.redhat.io/ubi10/perl-540:latest"),
-            ("5.32-ubi9", "registry.redhat.io/ubi9/perl-532:latest"),
-            ("5.32-ubi8", "registry.redhat.io/ubi8/perl-532:latest"),
-            ("5.26-ubi8", "registry.redhat.io/ubi8/perl-526:latest"),
+            ("5.40-ubi10", "registry.redhat.io/ubi10/perl-540:latest", True),
+            ("5.32-ubi9", "registry.redhat.io/ubi9/perl-532:latest", True),
+            ("5.32-ubi8", "registry.redhat.io/ubi8/perl-532:latest", False),
+            ("5.26-ubi8", "registry.redhat.io/ubi8/perl-526:latest", True),
         ],
     )
-    def test_package_imagestream(self, version, registry):
+    def test_package_imagestream(self, version, registry, expected):
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry)
+        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/test/test_imagestreams_quickstart.py
+++ b/test/test_imagestreams_quickstart.py
@@ -25,6 +25,9 @@ if VERSION == "5.30-mod_fcgid":
 if VERSION == "5.26-mod_fcgid":
     VERSION = "5.26"
 
+if VERSION == "5.32" and OS == "rhel8":
+    pytest.skip("This version is not being tested as it is deprecated")
+
 new_version = VERSION.replace(".", "")
 
 # Replacement with 'test_python_s2i_templates'


### PR DESCRIPTION
and update the README.md to reflect this change and suggest rhel9 instead

<!-- issue-commentator = {"comment-id":"3108323804"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3108560134","data":[{"id":"90cbda97-1daf-43a4-992d-0798face381d","name":"Fedora - 5.40","status":"complete","outcome":"passed","runTime":854.398686,"created":"2025-07-28T06:57:21.877056","updated":"2025-07-28T06:57:21.877063","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/90cbda97-1daf-43a4-992d-0798face381d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/90cbda97-1daf-43a4-992d-0798face381d/pipeline.log\">pipeline</a>"]},{"id":"7215e69d-fc48-42cf-b481-1cf76634b5d9","name":"RHEL8 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1605.870126,"created":"2025-07-24T13:05:02.250919","updated":"2025-07-24T13:05:02.250932","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7215e69d-fc48-42cf-b481-1cf76634b5d9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7215e69d-fc48-42cf-b481-1cf76634b5d9/pipeline.log\">pipeline</a>"]},{"id":"a56b4ec7-ff6b-46c7-a198-1f151fbe9496","name":"RHEL9 - 5.32","status":"complete","outcome":"passed","runTime":1819.957929,"created":"2025-07-24T13:05:08.557601","updated":"2025-07-24T13:05:08.557610","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a56b4ec7-ff6b-46c7-a198-1f151fbe9496\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a56b4ec7-ff6b-46c7-a198-1f151fbe9496/pipeline.log\">pipeline</a>"]},{"id":"ea3e6ec0-e8d3-4e6a-88f0-f87466e02f7d","name":"RHEL8 - OpenShift 4 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1489.124894,"created":"2025-07-24T13:05:39.722478","updated":"2025-07-24T13:05:39.722489","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ea3e6ec0-e8d3-4e6a-88f0-f87466e02f7d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ea3e6ec0-e8d3-4e6a-88f0-f87466e02f7d/pipeline.log\">pipeline</a>"]},{"id":"fb7e2309-3a23-4f9a-bee7-3cb28815dfd3","name":"CentOS Stream 10 - 5.40","status":"complete","outcome":"passed","runTime":829.991664,"created":"2025-07-28T06:57:23.999178","updated":"2025-07-28T06:57:23.999185","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fb7e2309-3a23-4f9a-bee7-3cb28815dfd3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fb7e2309-3a23-4f9a-bee7-3cb28815dfd3/pipeline.log\">pipeline</a>"]},{"id":"16bacecb-6358-4ac5-8093-eb5967af5847","name":"Fedora - 5.36","status":"complete","outcome":"passed","runTime":914.43235,"created":"2025-07-28T06:57:21.746087","updated":"2025-07-28T06:57:21.746096","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/16bacecb-6358-4ac5-8093-eb5967af5847\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/16bacecb-6358-4ac5-8093-eb5967af5847/pipeline.log\">pipeline</a>"]},{"id":"4c1762eb-61ea-4918-aa18-d3e8c9656872","name":"RHEL10 - PyTest - OpenShift 4 - 5.40","status":"complete","outcome":"passed","runTime":2113.613566,"created":"2025-07-24T13:05:57.875639","updated":"2025-07-24T13:05:57.875646","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4c1762eb-61ea-4918-aa18-d3e8c9656872\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4c1762eb-61ea-4918-aa18-d3e8c9656872/pipeline.log\">pipeline</a>"]},{"id":"4a6edea6-35fa-4e8c-aef8-8be3c55a62b5","name":"CentOS Stream 9 - 5.32","status":"complete","outcome":"passed","runTime":1609.690426,"created":"2025-07-24T13:04:59.712680","updated":"2025-07-24T13:04:59.712695","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4a6edea6-35fa-4e8c-aef8-8be3c55a62b5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4a6edea6-35fa-4e8c-aef8-8be3c55a62b5/pipeline.log\">pipeline</a>"]},{"id":"0e63f563-30a8-4b27-9d0e-77623f533405","name":"Fedora - 5.38","runTime":966.396616,"created":"2025-07-28T06:57:22.703319","updated":"2025-07-28T06:57:22.703325","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/0e63f563-30a8-4b27-9d0e-77623f533405\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0e63f563-30a8-4b27-9d0e-77623f533405/pipeline.log\">pipeline</a>"]},{"id":"fdf875bb-b3f1-472c-a3f4-cc7fd4d818b6","name":"RHEL10 - 5.40","status":"complete","outcome":"passed","runTime":1443.000425,"created":"2025-07-24T13:05:10.416752","updated":"2025-07-24T13:05:10.416758","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fdf875bb-b3f1-472c-a3f4-cc7fd4d818b6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fdf875bb-b3f1-472c-a3f4-cc7fd4d818b6/pipeline.log\">pipeline</a>"]},{"id":"bf37c00c-4f16-4f73-8cfa-d9b01920d13b","name":"RHEL10 - OpenShift 4 - 5.40","status":"complete","outcome":"passed","runTime":1315.094818,"created":"2025-07-24T13:05:58.304836","updated":"2025-07-24T13:05:58.304846","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf37c00c-4f16-4f73-8cfa-d9b01920d13b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf37c00c-4f16-4f73-8cfa-d9b01920d13b/pipeline.log\">pipeline</a>"]},{"id":"1e024b2c-02c8-424c-b7b2-7c13b6993beb","name":"RHEL9 - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":1563.554137,"created":"2025-07-24T13:05:15.700858","updated":"2025-07-24T13:05:15.700867","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1e024b2c-02c8-424c-b7b2-7c13b6993beb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1e024b2c-02c8-424c-b7b2-7c13b6993beb/pipeline.log\">pipeline</a>"]},{"id":"44e2664c-aa26-4dd8-bc03-7b14c3e664fd","name":"RHEL8 - PyTest - OpenShift 4 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1752.415914,"created":"2025-07-24T13:05:33.940092","updated":"2025-07-24T13:05:33.940101","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/44e2664c-aa26-4dd8-bc03-7b14c3e664fd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/44e2664c-aa26-4dd8-bc03-7b14c3e664fd/pipeline.log\">pipeline</a>"]},{"id":"ba33bac0-cbaf-448f-8188-f9e0f62aa6f1","name":"RHEL9 - PyTest - OpenShift 4 - 5.32","status":"complete","outcome":"passed","runTime":2239.663261,"created":"2025-07-24T13:05:52.451776","updated":"2025-07-24T13:05:52.451782","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ba33bac0-cbaf-448f-8188-f9e0f62aa6f1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ba33bac0-cbaf-448f-8188-f9e0f62aa6f1/pipeline.log\">pipeline</a>"]}]} -->