### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/5.40/Dockerfile.rhel10
+++ b/5.40/Dockerfile.rhel10
@@ -28,7 +28,6 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       name="ubi10/${NAME}-${PERL_SHORT_VER}" \
       com.redhat.component="${NAME}-${PERL_SHORT_VER}-container" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- issue-commentator = {"comment-id":"3279373707"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3279466072","data":[{"id":"21ca7b87-d495-4a57-83c4-abb1c1aaee08","name":"RHEL8 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1429.839783,"created":"2025-09-11T09:01:48.503761","updated":"2025-09-11T09:01:48.503766","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/21ca7b87-d495-4a57-83c4-abb1c1aaee08\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/21ca7b87-d495-4a57-83c4-abb1c1aaee08/pipeline.log\">pipeline</a>"]},{"id":"f5f962b5-33a3-46f1-92ce-5fef696a3f2e","name":"Fedora - 5.36","status":"complete","outcome":"passed","runTime":799.964296,"created":"2025-09-11T09:15:47.718550","updated":"2025-09-11T09:15:47.718556","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f5f962b5-33a3-46f1-92ce-5fef696a3f2e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f5f962b5-33a3-46f1-92ce-5fef696a3f2e/pipeline.log\">pipeline</a>"]},{"id":"349a83c9-a7c9-4e8f-a8dc-893f5a9c7d9a","name":"RHEL9 - 5.32","status":"complete","outcome":"passed","runTime":1633.736951,"created":"2025-09-11T09:08:10.285739","updated":"2025-09-11T09:08:10.285745","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/349a83c9-a7c9-4e8f-a8dc-893f5a9c7d9a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/349a83c9-a7c9-4e8f-a8dc-893f5a9c7d9a/pipeline.log\">pipeline</a>"]},{"id":"1016dae0-9b86-4bfb-9af6-81f2380b6d38","name":"Fedora - 5.40","status":"complete","outcome":"passed","runTime":796.739095,"created":"2025-09-11T09:23:22.461641","updated":"2025-09-11T09:23:22.461650","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1016dae0-9b86-4bfb-9af6-81f2380b6d38\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1016dae0-9b86-4bfb-9af6-81f2380b6d38/pipeline.log\">pipeline</a>"]},{"id":"d91d2899-5ff6-4324-a1b9-d2b8d70ed169","name":"CentOS Stream 10 - 5.40","status":"complete","outcome":"passed","runTime":914.609742,"created":"2025-09-11T09:30:49.614446","updated":"2025-09-11T09:30:49.614454","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d91d2899-5ff6-4324-a1b9-d2b8d70ed169\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d91d2899-5ff6-4324-a1b9-d2b8d70ed169/pipeline.log\">pipeline</a>"]},{"id":"008c7afd-68e4-40b7-9e73-b592dfa494b2","name":"Fedora - 5.38","status":"complete","outcome":"passed","runTime":820.018526,"created":"2025-09-11T09:41:07.817501","updated":"2025-09-11T09:41:07.817508","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/008c7afd-68e4-40b7-9e73-b592dfa494b2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/008c7afd-68e4-40b7-9e73-b592dfa494b2/pipeline.log\">pipeline</a>"]},{"id":"ffb5d77e-f012-4b11-b0ed-d533d8c92e87","name":"CentOS Stream 9 - 5.32","status":"complete","outcome":"passed","runTime":1027.461741,"created":"2025-09-11T09:39:40.599804","updated":"2025-09-11T09:39:40.599812","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ffb5d77e-f012-4b11-b0ed-d533d8c92e87\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ffb5d77e-f012-4b11-b0ed-d533d8c92e87/pipeline.log\">pipeline</a>"]},{"id":"e03d7af5-a57f-4a1a-935c-8185591cdc67","name":"RHEL10 - 5.40","runTime":1287.195526,"created":"2025-09-11T09:36:44.241973","updated":"2025-09-11T09:36:44.241980","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e03d7af5-a57f-4a1a-935c-8185591cdc67\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e03d7af5-a57f-4a1a-935c-8185591cdc67/pipeline.log\">pipeline</a>"]}]} -->