### PR TITLE
Add GitHub Action to run PyTest for perl-container

### DIFF
--- a/.github/workflows/container-pytest.yml
+++ b/.github/workflows/container-pytest.yml
@@ -1,0 +1,30 @@
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  container-tests:
+    name: "Container PyTest: ${{ matrix.version }} - ${{ matrix.os_test }}"
+    runs-on: ubuntu-latest
+    concurrency:
+      group: container-pytest-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ "5.26", "5.26-mod_fcgid", "5.30", "5.32", "5.34", "5.36", "5.38", "5.40" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s" ]
+        test_case: [ "container-pytest" ]
+
+    if: |
+      github.event.issue.pull_request
+      && (contains(github.event.comment.body, '[test-pytest]') || contains(github.event.comment.body, '[test-all]'))
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    steps:
+      - uses: sclorg/tfaga-wrapper@main
+        with:
+          os_test: ${{ matrix.os_test }}
+          version: ${{ matrix.version }}
+          test_case: ${{ matrix.test_case }}
+          public_api_key: ${{ secrets.TF_PUBLIC_API_KEY }}
+          private_api_key: ${{ secrets.TF_INTERNAL_API_KEY }}


### PR DESCRIPTION
Add GitHub Action to run PyTest for perl-container

Without this commit repository is not able
to run PyTest from tests/ repository.

The script that will be used for running is
`run-pytest`


