### PR TITLE
Re-enablement 532 rhel8

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Table start
 |5.26-mod_fcgid||||<details><summary>✓</summary>`registry.redhat.io/rhel8/perl-526-mod_fcgid`</details>|||
 |5.26|||||||
 |5.30|||||||
-|5.32|<details><summary>✓</summary>`quay.io/sclorg/perl-532-c9s`</details>||||<details><summary>✓</summary>`registry.redhat.io/rhel9/perl-532`</details>||
+|5.32|<details><summary>✓</summary>`quay.io/sclorg/perl-532-c9s`</details>|||<details><summary>✓</summary>`registry.redhat.io/rhel8/perl-532`</details>|<details><summary>✓</summary>`registry.redhat.io/rhel9/perl-532`</details>||
 |5.34|||||||
 |5.36|||<details><summary>✓</summary>`quay.io/fedora/perl-536`</details>||||
 |5.38|||<details><summary>✓</summary>`quay.io/fedora/perl-538`</details>||||

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -12,7 +12,7 @@
     latest: "5.40-ubi10"
     distros:
       - name: UBI 8
-        app_versions: ["5.26"]
+        app_versions: ["5.26", "5.32"]
 
       - name: UBI 9
         app_versions: ["5.32"]
@@ -24,7 +24,7 @@
     latest: "5.40-ubi10"
     distros:
       - name: UBI 8
-        app_versions: ["5.26"]
+        app_versions: ["5.26", "5.32"]
 
       - name: UBI 9
         app_versions: ["5.32"]
@@ -36,7 +36,7 @@
     latest: "5.40-ubi10"
     distros:
       - name: UBI 8
-        app_versions: ["5.26"]
+        app_versions: ["5.26", "5.32"]
 
       - name: UBI 9
         app_versions: ["5.32"]

--- a/imagestreams/perl-centos.json
+++ b/imagestreams/perl-centos.json
@@ -29,6 +29,25 @@
         }
       },
       {
+        "name": "5.32-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Perl 5.32 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
+          "iconClass": "icon-perl",
+          "tags": "builder,perl",
+          "version": "5.32",
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/perl-532:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "5.32-ubi9",
         "annotations": {
           "openshift.io/display-name": "Perl 5.32 (UBI 9)",

--- a/imagestreams/perl-rhel-aarch64.json
+++ b/imagestreams/perl-rhel-aarch64.json
@@ -29,6 +29,25 @@
         }
       },
       {
+        "name": "5.32-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Perl 5.32 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
+          "iconClass": "icon-perl",
+          "tags": "builder,perl",
+          "version": "5.32",
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/perl-532:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "5.32-ubi9",
         "annotations": {
           "openshift.io/display-name": "Perl 5.32 (UBI 9)",

--- a/imagestreams/perl-rhel.json
+++ b/imagestreams/perl-rhel.json
@@ -29,6 +29,25 @@
         }
       },
       {
+        "name": "5.32-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Perl 5.32 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Perl 5.32 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.32/README.md.",
+          "iconClass": "icon-perl",
+          "tags": "builder,perl",
+          "version": "5.32",
+          "sampleRepo": "https://github.com/sclorg/dancer-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/perl-532:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "5.32-ubi9",
         "annotations": {
           "openshift.io/display-name": "Perl 5.32 (UBI 9)",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,8 +43,3 @@ VARS = Vars(
 )
 
 IMAGE_TAG = f"mysql:{VARS.MYSQL_VERSION}"
-
-
-def skip_helm_charts_tests():
-    if VARS.VERSION == "5.32" and VARS.OS == "rhel8":
-        skip(f"Skipping Helm Charts tests for {VARS.VERSION} on {VARS.OS}.")

--- a/test/test_ocp_helm_dancer_mysql_template.py
+++ b/test/test_ocp_helm_dancer_mysql_template.py
@@ -21,7 +21,6 @@ class TestHelmPerlDancerMysqlAppTemplate:
         Test checks if Helm imagestream and Helm perl dancer application
         works properly and response is as expected.
         """
-        skip_helm_charts_tests()
         self.hc_api.package_name = "redhat-perl-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/test/test_ocp_helm_perl_imagestreams.py
+++ b/test/test_ocp_helm_perl_imagestreams.py
@@ -24,18 +24,18 @@ class TestHelmRHELPerlImageStreams:
         self.hc_api.delete_project()
 
     @pytest.mark.parametrize(
-        "version,registry,expected",
+        "version,registry",
         [
-            ("5.40-ubi10", "registry.redhat.io/ubi10/perl-540:latest", True),
-            ("5.32-ubi9", "registry.redhat.io/ubi9/perl-532:latest", True),
-            ("5.32-ubi8", "registry.redhat.io/ubi8/perl-532:latest", False),
-            ("5.26-ubi8", "registry.redhat.io/ubi8/perl-526:latest", True),
+            ("5.40-ubi10", "registry.redhat.io/ubi10/perl-540:latest"),
+            ("5.32-ubi9", "registry.redhat.io/ubi9/perl-532:latest"),
+            ("5.32-ubi8", "registry.redhat.io/ubi8/perl-532:latest"),
+            ("5.26-ubi8", "registry.redhat.io/ubi8/perl-526:latest"),
         ],
     )
-    def test_package_imagestream(self, version, registry, expected):
+    def test_package_imagestream(self, version, registry):
         """
         Test checks if Helm imagestreams are present
         """
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected
+        assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/test/test_ocp_imagestreams_quickstart.py
+++ b/test/test_ocp_imagestreams_quickstart.py
@@ -24,7 +24,6 @@ class TestImagestreamsQuickstart:
         The response is taken from POD `command-app`
         executed inside the same project.
         """
-        skip_helm_charts_tests()
         service_name = f"perl-{VARS.SHORT_VERSION}-testing"
         assert self.oc_api.imagestream_quickstart(
             imagestream_file="imagestreams/perl-rhel.json",

--- a/test/test_ocp_latest_imagestreams.py
+++ b/test/test_ocp_latest_imagestreams.py
@@ -14,5 +14,5 @@ class TestLatestImagestreams:
         Test checks if local imagestream is the latest one
         """
         self.latest_version = self.isc.get_latest_version()
-        assert self.latest_version != ""
+        assert self.latest_version
         self.isc.check_imagestreams(self.latest_version)


### PR DESCRIPTION
This pull request enables building and testing
perl-532 for RHEL8.

This version has full time length support

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4601962493"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4602083568","data":[{"id":"796746f3-8f46-44cc-8923-bdf76a7d6a13","name":"Fedora - 5.38","status":"complete","outcome":"passed","runTime":959.483009,"created":"2026-06-02T11:32:44.131196","updated":"2026-06-02T11:32:44.131202","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/796746f3-8f46-44cc-8923-bdf76a7d6a13\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/796746f3-8f46-44cc-8923-bdf76a7d6a13/pipeline.log\">pipeline</a>"]},{"id":"389db996-aa16-4b2b-bf91-aa79f20f576a","name":"Fedora - 5.36","status":"complete","outcome":"passed","runTime":894.33715,"created":"2026-06-02T11:32:46.028442","updated":"2026-06-02T11:32:46.028450","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/389db996-aa16-4b2b-bf91-aa79f20f576a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/389db996-aa16-4b2b-bf91-aa79f20f576a/pipeline.log\">pipeline</a>"]},{"id":"0bc742b4-05d6-4a0a-868d-e6ae4fc90f50","name":"Fedora - PyTest - 5.40","status":"complete","outcome":"passed","runTime":919.112043,"created":"2026-06-02T11:32:44.298982","updated":"2026-06-02T11:32:44.298990","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0bc742b4-05d6-4a0a-868d-e6ae4fc90f50\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0bc742b4-05d6-4a0a-868d-e6ae4fc90f50/pipeline.log\">pipeline</a>"]},{"id":"64449030-fb35-4a12-ae89-5283520a6d75","name":"CentOS Stream 9 - 5.32","status":"complete","outcome":"passed","runTime":1041.355639,"created":"2026-06-02T11:32:43.220923","updated":"2026-06-02T11:32:43.220928","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/64449030-fb35-4a12-ae89-5283520a6d75\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/64449030-fb35-4a12-ae89-5283520a6d75/pipeline.log\">pipeline</a>"]},{"id":"a1d457ea-57c6-4feb-835d-09e34fd69350","name":"CentOS Stream 10 - 5.40","status":"complete","outcome":"passed","runTime":1108.756007,"created":"2026-06-02T11:32:42.273053","updated":"2026-06-02T11:32:42.273059","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a1d457ea-57c6-4feb-835d-09e34fd69350\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a1d457ea-57c6-4feb-835d-09e34fd69350/pipeline.log\">pipeline</a>"]},{"id":"a059f867-ce8b-4aff-8225-fa298a2d1878","name":"CentOS Stream 9 - PyTest - 5.32","status":"complete","outcome":"passed","runTime":1180.572642,"created":"2026-06-02T11:32:44.521161","updated":"2026-06-02T11:32:44.521170","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a059f867-ce8b-4aff-8225-fa298a2d1878\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a059f867-ce8b-4aff-8225-fa298a2d1878/pipeline.log\">pipeline</a>"]},{"id":"a63fa8a8-c60a-4929-a04b-02b5bc0d859e","name":"CentOS Stream 10 - PyTest - 5.40","status":"complete","outcome":"passed","runTime":1140.575095,"created":"2026-06-02T11:32:42.465347","updated":"2026-06-02T11:32:42.465353","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a63fa8a8-c60a-4929-a04b-02b5bc0d859e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a63fa8a8-c60a-4929-a04b-02b5bc0d859e/pipeline.log\">pipeline</a>"]},{"id":"238ce732-67fd-4d35-833c-174df3c6ee58","name":"RHEL8 - PyTest - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1515.896503,"created":"2026-06-02T11:32:45.768923","updated":"2026-06-02T11:32:45.768929","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/238ce732-67fd-4d35-833c-174df3c6ee58\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/238ce732-67fd-4d35-833c-174df3c6ee58/pipeline.log\">pipeline</a>"]},{"id":"d82dc50d-1ada-43ee-9ea2-c98fc2886ec7","name":"RHEL8 - 5.26-mod_fcgid","status":"complete","outcome":"passed","runTime":1453.748441,"created":"2026-06-02T11:32:42.813415","updated":"2026-06-02T11:32:42.813420","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d82dc50d-1ada-43ee-9ea2-c98fc2886ec7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d82dc50d-1ada-43ee-9ea2-c98fc2886ec7/pipeline.log\">pipeline</a>"]},{"id":"fbef3b94-e08e-4799-9802-0d485d1d6491","name":"RHEL8 - 5.32","status":"complete","outcome":"passed","runTime":1500.707881,"created":"2026-06-02T11:34:09.100704","updated":"2026-06-02T11:34:09.100714","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fbef3b94-e08e-4799-9802-0d485d1d6491\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fbef3b94-e08e-4799-9802-0d485d1d6491/pipeline.log\">pipeline</a>"]},{"id":"1bfb85bf-c5d8-49fc-8ec8-319f3e6425f6","name":"RHEL9 - Unsubscribed host - PyTest - 5.32","status":"complete","outcome":"passed","runTime":1750.953031,"created":"2026-06-02T11:32:42.653671","updated":"2026-06-02T11:32:42.653678","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bfb85bf-c5d8-49fc-8ec8-319f3e6425f6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bfb85bf-c5d8-49fc-8ec8-319f3e6425f6/pipeline.log\">pipeline</a>"]},{"id":"6314cf3b-0736-4d87-b112-7c58082838a5","name":"RHEL10 - Unsubscribed host - 5.40","status":"complete","outcome":"passed","runTime":1730.807834,"created":"2026-06-02T11:32:42.696164","updated":"2026-06-02T11:32:42.696172","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6314cf3b-0736-4d87-b112-7c58082838a5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6314cf3b-0736-4d87-b112-7c58082838a5/pipeline.log\">pipeline</a>"]},{"id":"30bdf3ac-f408-4b58-89ad-a8e985e64abd","name":"RHEL9 - Unsubscribed host - 5.32","status":"complete","outcome":"passed","runTime":1752.81934,"created":"2026-06-02T11:32:42.411788","updated":"2026-06-02T11:32:42.411795","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/30bdf3ac-f408-4b58-89ad-a8e985e64abd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/30bdf3ac-f408-4b58-89ad-a8e985e64abd/pipeline.log\">pipeline</a>"]},{"id":"6de0e05d-b46b-4df0-8f5a-9f4cd68554df","name":"RHEL10 - Unsubscribed host - PyTest - 5.40","status":"complete","outcome":"passed","runTime":1770.332738,"created":"2026-06-02T11:32:42.473030","updated":"2026-06-02T11:32:42.473036","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6de0e05d-b46b-4df0-8f5a-9f4cd68554df\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6de0e05d-b46b-4df0-8f5a-9f4cd68554df/pipeline.log\">pipeline</a>"]},{"id":"d0e6824a-fa30-4e2e-8417-5ff5c3b1c2f9","name":"RHEL10 - PyTest - 5.40","status":"complete","outcome":"passed","runTime":1840.316329,"created":"2026-06-02T11:32:44.894775","updated":"2026-06-02T11:32:44.894782","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0e6824a-fa30-4e2e-8417-5ff5c3b1c2f9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0e6824a-fa30-4e2e-8417-5ff5c3b1c2f9/pipeline.log\">pipeline</a>"]},{"id":"d1a9bbcd-69f0-419a-8d7a-718fb6d1347f","name":"RHEL9 - PyTest - 5.32","status":"complete","outcome":"passed","runTime":1875.025608,"created":"2026-06-02T11:32:44.021576","updated":"2026-06-02T11:32:44.021582","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1a9bbcd-69f0-419a-8d7a-718fb6d1347f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1a9bbcd-69f0-419a-8d7a-718fb6d1347f/pipeline.log\">pipeline</a>"]},{"id":"96d39c45-a036-41ac-acae-2dd773d4a5c4","name":"Fedora - PyTest - 5.38","status":"complete","outcome":"passed","runTime":927.298897,"created":"2026-06-02T11:49:09.173552","updated":"2026-06-02T11:49:09.173559","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/96d39c45-a036-41ac-acae-2dd773d4a5c4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/96d39c45-a036-41ac-acae-2dd773d4a5c4/pipeline.log\">pipeline</a>"]},{"id":"bdc398de-76bc-48f4-9f6b-f53c29333094","name":"RHEL8 - PyTest - 5.32","runTime":1422.08188,"created":"2026-06-02T11:49:03.477160","updated":"2026-06-02T11:49:03.477167","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdc398de-76bc-48f4-9f6b-f53c29333094\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdc398de-76bc-48f4-9f6b-f53c29333094/pipeline.log\">pipeline</a>"]}]} -->